### PR TITLE
Adjust div class to reflect partial name

### DIFF
--- a/app/views/bulkrax/importers/_oai_adventist_fields.html.erb
+++ b/app/views/bulkrax/importers/_oai_adventist_fields.html.erb
@@ -1,9 +1,9 @@
 <%# override to remove the thumbnail_url field %>
-<div class='oai_fields'>
+<div class='oai_adventist_fields'>
   <%= fi.input :base_url, as: :string, input_html: { value: importer.parser_fields['base_url'] } %>
-  
+
   <%= fi.input :metadata_prefix, as: :string, hint: 'Such as oai_dc, dcterms or oai_qdc', input_html: { value: importer.parser_fields['metadata_prefix'] } %>
-  
+
   <%= fi.input :set, collection: [importer.parser_fields['set']], label: 'Set (source)', selected: importer.parser_fields['set'] %>
   <button type="button" class="btn btn-default refresh-set-source">Refresh Sets</button>
 


### PR DESCRIPTION
**Prior to this commit**, when you were on the `/importers/new` page you would see the form fields for the OAI ingester; even though you hadn't selected that parser.

The reason is that in Bulkrax the name of the partial is used to hide the section with a HTML class attribute that is the named partial (e.g. `_oai_adventist_fields.html.erb` and `class="oai_adventist_fields"`)

Below is the [Bulkrax code demonstrating that functionality][1]:

```
  <% Bulkrax.parsers.map{ |p| p[:partial]}.uniq.each do |partial| %>
  if($('.<%= partial %>').length > 0) {
    window.<%= partial %> = $('.<%= partial %>').detach()
  }
  <% end %>
```

**With this commit**, when you haven't selected a parser, there will be no parser fields.  Then when you select the parser, the browser will render the associated fields.

[1]:https://github.com/samvera-labs/bulkrax/blob/e88d0ea349afda5b3068836aa36ef86c93d4c62d/app/assets/javascripts/bulkrax/importers.js.erb#L112-L116
