### PR TITLE
Step 1 of migrating Slug Predicate

### DIFF
--- a/app/models/concerns/slug_bug.rb
+++ b/app/models/concerns/slug_bug.rb
@@ -9,11 +9,8 @@ module SlugBug
     after_update :remove_index_and_reindex
   end
 
-  class_methods do
-  end
-
   def to_param
-    slug || id
+    slug_for_upgrade || slug || id
   end
 
   def set_slug
@@ -22,15 +19,14 @@ module SlugBug
                 else
                   id
                 end
+    self.slug_for_upgrade = slug
   end
 
   private
 
     # Cribbed from https://gitlab.com/notch8/louisville-hyku/-/blob/main/app/models/custom_slugs/slug_behavior.rb#L14
     def remove_index_and_reindex
-      # rubocop:disable Rails/Blank
-      return unless slug.present?
-      # rubocop:enable Rails/Blank
+      return unless slug.present? || slug_for_upgrade.present?
 
       # if we have a slug with an existing record, previous indexes would have a different id,
       # resulting extraneous solr indexes remaining (one fedora object with two solr indexes to it)

--- a/app/models/slug_metadata.rb
+++ b/app/models/slug_metadata.rb
@@ -10,9 +10,23 @@ module SlugMetadata
              multiple: false do |index|
                index.as :stored_searchable
              end
+
+    # @deprecated
     # adding slug field for custom work urls
     property :slug, predicate: ::RDF::Vocab::DC.alternative, multiple: false do |index|
       index.as :stored_searchable
     end
+
+    # We need to move the above :slug from ::RDF::Vocab::DC.alternative to a different predicate.
+    #
+    # This is an internal application-only custom identifier for the use of slugs'
+    # It is important not to reuse any terms on the fedora items, as one would overwrite the other.
+    # This creates an internal term specifically for slug use which will never get overwritten.
+    property(
+      :slug_for_upgrade,
+      # NOTE: this is a made up URI; we don't need it to resolve to an actual page.
+      predicate: ::RDF::URI.intern('http://id.loc.gov/vocabulary/identifiers/slug'),
+      multiple: false
+    ) { |index| index.as :stored_searchable }
   end
 end


### PR DESCRIPTION
Prior to this commit, we have the slug's predicate writing to `DC.alternate`.  This is a mismapping, and one that will cause issues with the client's desired `alternate_title` property and the upgradability of the application (Hyrax 3.x introduces `alternate_title` that maps to the `DC.predicate`)

With this commit, we create a "shadow" attribute that updates in the same manner as the `slug`.  This prepares the way for a "schema" migration by ensuring that the new property (with the correct predicate) is being written to Fedora.

For reference on the renaming pattern:

- http://www.agiledata.org/essays/renameColumn.html
- https://crucialfelix.github.io/posts/renaming-database-columns-in-production/

Related to #77
