### PR TITLE
Ensuring we ignore the /hyrax directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,6 @@ node_modules
 /public/uv
 
 # Ignore Hyrax helm chart download
-hyrax
+/hyrax
 
 *~undo-tree~


### PR DESCRIPTION
The gitignore works as intended, however, one side effect is that this impacts how ripgrep (rg) and the Silver Searcher (ag) handle searches.

Prior to this commit, if I ran the following: `rg "next if"` (or `ag "next if"`)

I got:

```shell
./db/seeds.rb:  next if Site.instance.available_works.present?
./db/migrate/20200513060932_move_cnames_to_domain_names.rb:      next if a.domain_names.count > 0
./lib/importer/csv_parser.rb:          next if header == 'resource_type'
./lib/importer/mods_importer.rb:        next if File.directory?(filename)
./lib/importer/mods_parser.rb:        next if node.attributes.key?(type) && node.attributes[type].value == preferred_citation
./bin/encrypt-secrets:    next if file.match(/$enc/)
```

With this commit, if I run the same command I get:

```shell
./db/seeds.rb:  next if Site.instance.available_works.present?
./db/migrate/20200513060932_move_cnames_to_domain_names.rb:      next if a.domain_names.count > 0
./lib/importer/csv_parser.rb:          next if header == 'resource_type'
./lib/importer/mods_importer.rb:        next if File.directory?(filename)
./lib/importer/mods_parser.rb:        next if node.attributes.key?(type) && node.attributes[type].value == preferred_citation
./bin/encrypt-secrets:    next if file.match(/$enc/)
./app/actors/hyrax/actors/collections_membership_actor.rb:            next if attributes['id'].blank?
./app/actors/hyrax/actors/collections_membership_actor.rb:              next if existing_collections.include?(attributes['id'])
./app/actors/hyrax/actors/create_with_remote_files_actor.rb:            next if file_info.blank? || file_info[:url].blank?
./app/views/hyrax/journal_articles/_attribute_rows.html.erb:  next if [:title, :description, :license, :abstract].include? prop
./app/views/hyrax/theses/_attribute_rows.html.erb:  next if [:title, :description, :license, :abstract].include? prop
./app/views/hyrax/exam_papers/_attribute_rows.html.erb:  next if [:title, :description, :license].include? prop
./app/views/hyrax/datasets/_attribute_rows.html.erb:  next if [:title, :description, :license, :abstract].include? prop
./app/views/hyrax/conference_items/_attribute_rows.html.erb:  next if [:title, :description, :abstract, :license].include? prop
./app/views/hyrax/published_works/_attribute_rows.html.erb:  next if [:title, :description, :license, :abstract].include? prop
```

I can run `rg "next if" --no-ignore` to ignore the `.gitignore` file.
