### PR TITLE
Removing Related URLs override that rendered downloaded files

### DIFF
--- a/app/models/adventist_metadata.rb
+++ b/app/models/adventist_metadata.rb
@@ -36,6 +36,12 @@ module AdventistMetadata
     property :language, predicate: ::RDF::Vocab::DC11.language
     property :identifier, predicate: ::RDF::Vocab::DC.identifier
     property :based_near, predicate: ::RDF::Vocab::FOAF.based_near, class_name: Hyrax::ControlledVocabularies::Location
+
+    # Due to the mappings for Bulkrax the "related_url" is not exposed as a field we can "import
+    # into".  What do I mean by that?  For importers we map the related_url to "remote_files" then
+    # ingest those files.  However, we do also expose a means of assigning a "related_url" via the
+    # UI.  In that case we don't map that input to "remote_files" and instead write to the
+    # "related_url" property.
     property :related_url, predicate: ::RDF::RDFS.seeAlso
     property :bibliographic_citation, predicate: ::RDF::Vocab::DC.bibliographicCitation
     property :source, predicate: ::RDF::Vocab::DC.source do |index|

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -50,6 +50,7 @@ class SolrDocument
     language: 'language_tesim',
     publisher: 'publisher_tesim',
     relation: 'nesting_collection__pathnames_ssim',
+    related_url: 'related_url_tesim',
     rights: 'rights_statement_tesim',
     subject: 'subject_tesim',
     title: 'title_tesim',
@@ -64,9 +65,18 @@ class SolrDocument
     Addressable::URI.parse("https://#{Site.account.cname}#{thumbnail_path}").to_s
   end
 
-  def related_url
-    file_set_ids.map do |fs_id|
-      Hyrax::Engine.routes.url_helpers.download_path(fs_id)
-    end
-  end
+  # @note This commented out method is supplanted by adding the `related_url: 'related_url_tesim`
+  #       field semantics.
+  # @note I'm commenting this out because in Bulkrax the source `related_url` (e.g. from the CSV or
+  #       OAI ADL import) maps to `remote_files`.  The importers fetch the `remote_files` and attach
+  #       them as FileSets.  They do not write to `related_url`.  However, there is also the ability
+  #       to add a `related_url` via the UI.
+  #
+  # @see https://github.com/scientist-softserv/adventist-dl/issues/87
+  # @see # https://github.com/scientist-softserv/adventist-dl/blob/96cbb01f1bd858ec0b472fb89ce033e180dba4b1/config/initializers/bulkrax.rb#L62
+  # def related_url
+  #   file_set_ids.map do |fs_id|
+  #     Hyrax::Engine.routes.url_helpers.download_path(fs_id)
+  #   end
+  # end
 end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -17,7 +17,7 @@
 <%= presenter.attribute_to_html(:source, render_as: :faceted) %>
 <%= presenter.attribute_to_html(:place_of_publication) %>
 <%= presenter.attribute_to_html(:bibliographic_citation) %>
-<%= presenter.attribute_to_html(:remote_url) %>
+<%= presenter.attribute_to_html(:remote_url, render_as: :external_link) %>
 <%= presenter.attribute_to_html(:rights_statement) %>
 <%= presenter.attribute_to_html(:extent) %>
 <%= presenter.attribute_to_html(:date_issued, label: 'Date') %>


### PR DESCRIPTION
Prior to this commit, the `related_url` property was modified for showing records.  This modification meant that any values actually set in the `related_url` would not render (but were searchable).  To set those, you would need to do so via the UI.

Prior to and after this commit, Bulkrax's import mapping mapped `remote_files` from the `related_url`.  We use the CSV column of `related_url` (or XML node in the OAI ADL) to indicate files to download and attach (as FileSets).  The ingest process does not store these values in the `related_url` attribute of the Fedora document.

With this commit, we're preserving the import behavior (e.g. mapping from `related_url` to `remote_files`) and exposing the values for `related_url` that might have been entered via the UI.

_Note:_ This change highlights that we may have a misunderstanding in the mappings or could rename the import from field or accept what we have as an implementation detail/foible.

_Note:_ I normally don't like commenting out a method; however it is helpful to include that commented out method as a connection to the potential mapping disconnect.

Relates to #87, which includes an even deeper dive into the issue.
