### PR TITLE
Ensuring AARK renders for Generic Work and Image

### DIFF
--- a/app/presenters/hyrax/generic_work_presenter.rb
+++ b/app/presenters/hyrax/generic_work_presenter.rb
@@ -4,6 +4,6 @@
 #  `rails generate hyrax:work GenericWork`
 module Hyrax
   class GenericWorkPresenter < Hyku::WorkShowPresenter
-    delegate :abstract, :date_issued, :alt, :part_of, :place_of_publication, :remote_url, to: :solr_document
+    delegate :aark_id, :abstract, :date_issued, :alt, :part_of, :place_of_publication, :remote_url, to: :solr_document
   end
 end

--- a/app/presenters/hyrax/image_presenter.rb
+++ b/app/presenters/hyrax/image_presenter.rb
@@ -6,6 +6,6 @@ module Hyrax
   class ImagePresenter < Hyku::WorkShowPresenter
     # We do not use this generated ImagePresenter. Instead we use the
     # WorkShowPresenter
-    delegate :abstract, :date_issued, :alt, :part_of, :place_of_publication, :remote_url, to: :solr_document
+    delegate :aark_id, :abstract, :date_issued, :alt, :part_of, :place_of_publication, :remote_url, to: :solr_document
   end
 end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -15,6 +15,7 @@
 <% end %>
 <%= presenter.attribute_to_html(:part_of) %>
 <%= presenter.attribute_to_html(:source, render_as: :faceted) %>
+<%= presenter.attribute_to_html(:aark_id, label: t('dog_biscuits.fields.aark_id')) %>
 <%= presenter.attribute_to_html(:place_of_publication) %>
 <%= presenter.attribute_to_html(:bibliographic_citation) %>
 <%= presenter.attribute_to_html(:remote_url) %>


### PR DESCRIPTION
Prior to this commit the Image and Generic Work did not expose the AARK to the show page.  They did, however, expose the AARK for editing.

With this commit, the Image and Generic Work now expose the AARK field on the show page and leverage the dog biscuits specified translation.

Discovered while attempting to locally QA #111.  There is, however, a disconnect as the Image and Generic Work use the default SimpleForm i18n of `aark_id` and the others use the Dog Biscuits translation.  To normalize this, I added the `label: t('dog_biscuits.fields.aark_id')` option for rendering the `aark_id`.
