### PR TITLE
Style announcement & alerts

### DIFF
--- a/app/assets/stylesheets/adl-overrides/adl-overrides.scss
+++ b/app/assets/stylesheets/adl-overrides/adl-overrides.scss
@@ -275,6 +275,21 @@ body.public-facing {
     background-color: $lightgrey;
   }
 
+  // Announcement Content Block
+
+  div#announcement {
+    color: $darkgrey;
+    font-size: 15px;
+    background-color: $white;
+    border: 2px solid $mediumgrey;
+    padding-top: 0;
+    border-radius: 0;
+    p {
+      margin-top: 10px;
+      font-weight: 600;
+    }
+}
+
   // ALERTS
   .alert-info {
     color: $black;

--- a/app/assets/stylesheets/adl-overrides/adl-overrides.scss
+++ b/app/assets/stylesheets/adl-overrides/adl-overrides.scss
@@ -307,7 +307,7 @@ body.public-facing {
     }
     
     &.alert-info {
-      background: linear-gradient(#efefef, $white, $white, #efefef);
+      background: linear-gradient(#dde5ee, #f7f7f7, $white, #f7f7f7, #dde5ee);
     }
     
     &.alert-warning {

--- a/app/assets/stylesheets/adl-overrides/adl-overrides.scss
+++ b/app/assets/stylesheets/adl-overrides/adl-overrides.scss
@@ -292,7 +292,7 @@ body.public-facing {
 
   // ALERTS
 
-  .alert-success, .alert-info, .alert-warning {
+  .alert {
     color: $darkgrey;
     background: linear-gradient(#efefef, $white, $white, #efefef);
     border-color: $lightgreyborder;
@@ -302,8 +302,19 @@ body.public-facing {
       margin-right: 15px;
       margin-left: 15px;
     }
+    &.alert-success {
+      background: linear-gradient(#efefef, $white, $white, #efefef);
+    }
+    
+    &.alert-info {
+      background: linear-gradient(#efefef, $white, $white, #efefef);
+    }
+    
+    &.alert-warning {
+      background: linear-gradient(#fff7db, #f7f7f7, $white, #f7f7f7, #fff7db);
+    }
   }
-
+  
   .legend {
     color: $black !important;
   }

--- a/app/assets/stylesheets/adl-overrides/adl-overrides.scss
+++ b/app/assets/stylesheets/adl-overrides/adl-overrides.scss
@@ -291,23 +291,13 @@ body.public-facing {
 }
 
   // ALERTS
-  .alert-info {
-    color: $black;
+
+  .alert-success, .alert-info, .alert-warning {
+    color: $darkgrey;
     background-color: $lightgrey;
     border-color: transparent;
-    border: 0 solid transparent;
-  }
-  .alert-success {
-    color: $white;
-    background-color: $darkyellow;
-    border-color: transparent;
-    border: 0 solid transparent;
-  }
-  .alert-warning {
-    color: $black;
-    background-color: $darkyellow;
-    border-color: transparent;
-    border: 0 solid transparent;
+    margin-right: 0;
+    margin-left: 0;
   }
 
   .legend {

--- a/app/assets/stylesheets/adl-overrides/adl-overrides.scss
+++ b/app/assets/stylesheets/adl-overrides/adl-overrides.scss
@@ -294,10 +294,14 @@ body.public-facing {
 
   .alert-success, .alert-info, .alert-warning {
     color: $darkgrey;
-    background-color: $lightgrey;
-    border-color: transparent;
+    background: linear-gradient(#efefef, $white, $white, #efefef);
+    border-color: $lightgreyborder;
     margin-right: 0;
     margin-left: 0;
+    @media (max-width: $sm-max) {
+      margin-right: 15px;
+      margin-left: 15px;
+    }
   }
 
   .legend {

--- a/app/views/hyrax/homepage/_announcement.html.erb
+++ b/app/views/hyrax/homepage/_announcement.html.erb
@@ -1,4 +1,6 @@
-<%# OVERRIDE Hyrax 2.9.1 to remove unnecessary div & classes %>
+<%# OVERRIDE Hyrax 2.9.1 to remove unnecessary classes %>
 <% if display_content_block? @announcement_text %>
-  <%= displayable_content_block @announcement_text, id: 'announcement' %>
+  <div id="announcement">
+    <%= displayable_content_block @announcement_text%>
+  </div>
 <% end %>

--- a/app/views/hyrax/homepage/_announcement.html.erb
+++ b/app/views/hyrax/homepage/_announcement.html.erb
@@ -1,0 +1,4 @@
+<%# OVERRIDE Hyrax 2.9.1 to remove unnecessary div & classes %>
+<% if display_content_block? @announcement_text %>
+  <%= displayable_content_block @announcement_text, id: 'announcement' %>
+<% end %>

--- a/app/views/hyrax/homepage/index.html.erb
+++ b/app/views/hyrax/homepage/index.html.erb
@@ -4,7 +4,7 @@
 
 <%# OVERRIDE remove share work button and add custom partials  %>
 
-<div class="row home-content">
+<div class="home-content">
   <%= render '/adl/featured_collections' %>
   <%= render '/adl/featured_works' %>
 </div>

--- a/app/views/layouts/homepage.html.erb
+++ b/app/views/layouts/homepage.html.erb
@@ -1,11 +1,9 @@
 <%# OVERRIDE HYRAX VERSION 2.9.1 - add share your work button & change inline bootstrap styles%>
+<%= render 'hyrax/homepage/announcement' if controller_name == 'homepage' %>
 <% content_for(:navbar) do %>
   <div class="image-masthead custom-masthead" style="background-image: url('<%= banner_image %>')">
     <%= render '/controls' %>
   </div>
-<% end %>
-<% content_for(:precontainer_content) do %>
-  <%= render 'hyrax/homepage/announcement' if controller_name == 'homepage' %>
 <% end %>
 <%= render template: 'layouts/hyrax' %>
 

--- a/app/views/layouts/homepage.html.erb
+++ b/app/views/layouts/homepage.html.erb
@@ -1,5 +1,4 @@
 <%# OVERRIDE HYRAX VERSION 2.9.1 - add share your work button & change inline bootstrap styles%>
-<%= render 'hyrax/homepage/announcement' if controller_name == 'homepage' %>
 <% content_for(:navbar) do %>
   <div class="image-masthead custom-masthead" style="background-image: url('<%= banner_image %>')">
     <%= render '/controls' %>

--- a/app/views/layouts/hyrax.html.erb
+++ b/app/views/layouts/hyrax.html.erb
@@ -29,6 +29,7 @@
     <div class="skip-to-content">
       <%= link_to "Skip to Content", "#skip-to-content" %>
     </div>
+    <%= render 'hyrax/homepage/announcement' if controller_name == 'homepage' %>
     <%= render '/masthead' %>
     <%= content_for(:navbar) %>
     <%= content_for(:precontainer_content) %>


### PR DESCRIPTION
# Summary
style the announcement and alerts

# Screenshots

Announcement
<img width="1052" alt="image" src="https://user-images.githubusercontent.com/73361970/202269371-27cf035d-00a7-43b1-8bab-5029e91808a6.png">

Alerts

alert success
<img width="768" alt="image" src="https://user-images.githubusercontent.com/73361970/202277444-fc2e00fa-0ab0-49b2-ad65-3a4258514b63.png">

alert warning
<img width="824" alt="image" src="https://user-images.githubusercontent.com/73361970/202312660-6201f0e9-0098-4619-ae20-98fa05d1db76.png">

alert info
<img width="818" alt="image" src="https://user-images.githubusercontent.com/73361970/202313093-91433974-843e-4ea6-80e4-5ce9551608d2.png">


# Acceptance Criteria
- [ ] Announcement is styled as per the wireframe
- [ ] Alerts are a more enjoyable color to look at than bright yellow