### PR TITLE
Adding ordering to :creator (labeled as Author)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -144,3 +144,5 @@ gem 'blacklight_advanced_search'
 gem 'blacklight_range_limit', '6.5.0'
 
 gem 'dog_biscuits', git: 'https://github.com/samvera-labs/dog_biscuits.git'
+
+gem 'order_already'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -715,6 +715,8 @@ GEM
       sawyer (~> 0.8.0, >= 0.5.3)
     openseadragon (0.6.0)
       rails (> 3.2.0)
+    order_already (0.1.0)
+      rails-html-sanitizer (~> 1.4)
     orm_adapter (0.5.0)
     os (1.1.1)
     parallel (1.19.2)
@@ -1134,6 +1136,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   lograge
   mods (~> 2.4)
+  order_already
   parser (~> 2.5.3)
   pg
   pronto

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -7,4 +7,6 @@ class Collection < ActiveFedora::Base
   include SlugMetadata
   include AdventistMetadata
   self.indexer = CollectionIndexer
+
+  prepend OrderAlready.for(:creator)
 end

--- a/app/models/conference_item.rb
+++ b/app/models/conference_item.rb
@@ -17,4 +17,6 @@ class ConferenceItem < DogBiscuits::ConferenceItem
   include SlugMetadata
   include DogBiscuits::ConferenceItemMetadata
   before_save :combine_dates
+
+  prepend OrderAlready.for(:creator)
 end

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -17,4 +17,6 @@ class Dataset < DogBiscuits::Dataset
   include SlugMetadata
   include DogBiscuits::DatasetMetadata
   before_save :combine_dates
+
+  prepend OrderAlready.for(:creator)
 end

--- a/app/models/exam_paper.rb
+++ b/app/models/exam_paper.rb
@@ -17,4 +17,6 @@ class ExamPaper < DogBiscuits::ExamPaper
   include SlugMetadata
   include DogBiscuits::ExamPaperMetadata
   before_save :combine_dates
+
+  prepend OrderAlready.for(:creator)
 end

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -16,4 +16,6 @@ class GenericWork < ActiveFedora::Base
 
   self.indexer = WorkIndexer
   self.human_readable_type = 'Work'
+
+  prepend OrderAlready.for(:creator)
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -27,4 +27,6 @@ class Image < ActiveFedora::Base
   validates :title, presence: { message: 'Your work must have a title.' }
 
   self.human_readable_type = 'Image'
+
+  prepend OrderAlready.for(:creator)
 end

--- a/app/models/journal_article.rb
+++ b/app/models/journal_article.rb
@@ -22,4 +22,6 @@ class JournalArticle < DogBiscuits::JournalArticle
   include SlugMetadata
   include DogBiscuits::JournalArticleMetadata
   before_save :combine_dates
+
+  prepend OrderAlready.for(:creator)
 end

--- a/app/models/published_work.rb
+++ b/app/models/published_work.rb
@@ -22,4 +22,6 @@ class PublishedWork < DogBiscuits::PublishedWork
   include SlugMetadata
   include DogBiscuits::PublishedWorkMetadata
   before_save :combine_dates
+
+  prepend OrderAlready.for(:creator)
 end

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -24,4 +24,6 @@ class Thesis < DogBiscuits::Thesis
   include SlugMetadata
   include DogBiscuits::ThesisMetadata
   before_save :combine_dates
+
+  prepend OrderAlready.for(:creator)
 end


### PR DESCRIPTION
Prior to this commit, the order that we specified the `:creator` values were not necessarily remembered when we would round-trip data from Ruby to Fedora and back to Ruby.

With this commit, we introduce the OrderAlready gem for encoding the values for an attribute with a sort order.  And then declare the `:creator` property to be ordered.

This will require reingesting any records that already exist; or accepting the order that the application chooses when we round trip from Fedora to Ruby and back to Fedora.

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/84
- https://github.com/scientist-softserv/adventist-dl/issues/55

## Screenshots of related pages/data storage

<ul>
<li>
<details>
<summary>Edit Page Screenshot</summary>
<img width="819" alt="Hyku Work Edit Page Showing Ordered Authors" src="https://user-images.githubusercontent.com/2130/202456744-a87dca1a-e34b-4a70-a049-dcfda3d99957.png">
</details>
</li>
<li>
<details>
<summary>Show Page Screenshot</summary>
<img width="1155" alt="Hyku Work Show Page Showing Ordered Authors" src="https://user-images.githubusercontent.com/2130/202456976-24212847-1bf7-4339-8c84-84c91290db6c.png">
</details>
</li>
<li>
<details>
<summary>Fedora Page Screenshot</summary>
<img width="877" alt="Fedora Page Showing Ordered Authors" src="https://user-images.githubusercontent.com/2130/202457318-4898f2a8-e59e-40d1-9fca-170f262b0756.png">
</details>
</li>
<li>
<details>
<summary>SOLR Page Screenshot</summary>

![Screen Shot 2022-11-17 at 8 19 58 AM](https://user-images.githubusercontent.com/2130/202457453-6c203762-64d2-48bd-8ee2-6dc1650310d4.png)

</details>
</li>
</ul>
