### PR TITLE
Adding most of JournalArticle metadata to Collection

### DIFF
--- a/app/forms/hyrax/forms/collection_form_decorator.rb
+++ b/app/forms/hyrax/forms/collection_form_decorator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module Forms
+    module CollectionFormDecorator
+      # Terms that appear within the accordion
+      def secondary_terms
+        (super + Collection::ADDITIONAL_TERMS).sort
+      end
+    end
+  end
+end
+
+Hyrax::Forms::CollectionForm.terms += Collection::ADDITIONAL_TERMS
+Hyrax::Forms::CollectionForm.prepend(Hyrax::Forms::CollectionFormDecorator)

--- a/app/indexers/collection_indexer.rb
+++ b/app/indexers/collection_indexer.rb
@@ -5,10 +5,17 @@ class CollectionIndexer < Hyrax::CollectionIndexer
   # provide your own metadata and indexing.
   include Hyrax::IndexesBasicMetadata
 
+  # This is echoing the JournalArticleIndexer; see
+  # https://github.com/scientist-softserv/adventist-dl/issues/49
+  include DogBiscuits::IndexesCommon
+
   # Uncomment this block if you want to add custom indexing behavior:
   # def generate_solr_document
   #  super.tap do |solr_doc|
   #    solr_doc['my_custom_field_ssim'] = object.my_custom_property
   #  end
   # end
+
+  # Add any custom indexing into here. Method must exist, but can be empty.
+  def do_local_indexing(solr_doc); end
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -6,7 +6,59 @@ class Collection < ActiveFedora::Base
   # You can replace these metadata if they're not suitable
   include SlugMetadata
   include AdventistMetadata
+
+  ADDITIONAL_TERMS = %i[abstract
+                        alt
+                        date
+                        date_accepted
+                        date_available
+                        date_issued
+                        date_published
+                        date_submitted
+                        department
+                        doi
+                        former_identifier
+                        funder
+                        issue_number
+                        lat
+                        location
+                        long
+                        managing_organisation
+                        note
+                        official_url
+                        output_of
+                        pagination
+                        part_of
+                        place_of_publication
+                        publication_status].freeze
+
+  include DogBiscuits::JournalArticleMetadata
+  include DogBiscuits::BibliographicCitation
+  include DogBiscuits::DateIssued
+  include DogBiscuits::Geo
+  include DogBiscuits::PlaceOfPublication
+  include DogBiscuits::RemoteUrl
+
   self.indexer = CollectionIndexer
 
   prepend OrderAlready.for(:creator)
+
+  # What's going on here?
+  #
+  # Without the following two lines of code, we get the following error when we attempt to persist a
+  # collection via the UI:
+  #
+  #   ActiveTriples::UndefinedPropertyError in Hyrax::Dashboard::CollectionsController#update
+  #   The property `abstract` is not defined on class 'Collection::GeneratedResourceSchema'
+  #
+  # In my exploration, ActiveFedora::FedoraAttributes.resource_class is being called before we've
+  # included the :abstract property (via the `include DogBiscuits::JournalArticleMetadata` line).
+  # To circumvent this, I'm nullifying `@generated_resource_class` on the Collection and then
+  # calling `Collection.resource_class`.
+  #
+  # Yes this is violating the rules of encapsulation, but this resolves the above exception.
+  #
+  # @see https://github.com/samvera/active_fedora/blob/6f48c18f919ed140682be05aba1b43a99461b3a7/lib/active_fedora/fedora_attributes.rb#L58-L69
+  instance_variable_set(:@generated_resource_class, nil)
+  resource_class
 end

--- a/app/presenters/hyrax/collection_presenter_decorator.rb
+++ b/app/presenters/hyrax/collection_presenter_decorator.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module CollectionPresenterDecorator
+    module ClassMethods
+      delegate(*Collection::ADDITIONAL_TERMS, to: :solr_document)
+
+      # Terms is the list of fields displayed by
+      # app/views/collections/_show_descriptions.html.erb
+      def terms
+        super + Collection::ADDITIONAL_TERMS
+      end
+    end
+  end
+end
+
+# Why singleton_class?  I tried to use ActiveSupport::Concern.included and .class_methods but this
+# just didn't work.  Instead I'm leveraging the old-school Rails idiom of having a ClassMethods
+# module; and prepending that to the singleton_class (e.g. make the methods of the ClassMethods
+# module be class methods on the Hyrax::CollectionPresenter)
+Hyrax::CollectionPresenter.singleton_class.prepend(Hyrax::CollectionPresenterDecorator::ClassMethods)


### PR DESCRIPTION
The commit addresses:

1. Properties indexed for a `Collection`
2. Properties showed on a `Collection` show page
3. Properties persisted to Fedora
4. Properties exposed on the `Collection` edit page

**Note:** Our default searches omit collections; this is something to address.  And I created [Collections are not part of the searched objects][1] reflecting this.

Below are the steps taken as well as discussion concerning those steps.

**First**, I checked the `properties` differences between `JournalArticle` and `Collection`.  In the Rails console I ran:

`pp JournalArticle.properties.keys - Collection.properties.keys`

This returns all named properties that are on the `JournalArticle` but not on the `Collection`.

Prior to this commit that list was:

```ruby
["state", "proxy_depositor", "on_behalf_of", "arkivo_checksum", "owner",
"date_issued", "lat", "long", "alt", "place_of_publication", "abstract",
"date_available", "date_published", "date_submitted", "date_accepted",
"issue_number", "managing_organisation", "official_url", "orcid",
"pagination", "part_of", "publication_status", "refereed",
"volume_number", "preflabel", "altlabel", "rdfs_label", "rights_holder",
"rights_description", "date", "department", "funder", "language_code",
"output_of", "doi", "location", "note", "former_identifier"]
```

After this commit the list is:

```ruby
["state", "proxy_depositor", "on_behalf_of", "arkivo_checksum", "owner"]
```

- `state` :: This is an administrative metadata that is part of the mediated deposit workflow and not something that is exposed.
- `proxy_depositor` :: This is the field used when we allow proxy deposits (e.g. on behalf of someone else).  My suspicion is that this is not necessary.
- `on_behalf_of` :: This is the field that indicates who this was deposited on behalf of.  Related to `proxy_depositor`
- `arkivo_checksum` :: At present, I'm not aware of the purpose of this attribute.  It is not something explicitly requested by Adventist; but we'll want to explore.
- `owner` :: I believe this relates to the mediated deposit.

This first pass knocks the list from 38 missing properties to 5 missing properties.

**Second**, I needed to update the form; this involved adding a decorator and making adjustments to the Collection to handle what was an incorrect `Collection.resource_class` (see inline comments for more details).

**Third**, As I worked on the show page, there were properties not exposed on the SolrDocument (e.g. `altlabel`, `orcid`, `preflabel`). I'm unclear if these need to be exposed or not; so I went with not including it; in part because we're not already exposing them on the `JournalArticle`.

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/49

[1]:https://github.com/scientist-softserv/adventist-dl/issues/145
