### PR TITLE
Hide sections for non-adl tenants

### DIFF
--- a/app/views/adl/_about_section.html.erb
+++ b/app/views/adl/_about_section.html.erb
@@ -4,7 +4,6 @@
       <%= displayable_content_block @homepage_about_section_heading, class: 'h2' %>
     <% end %>
     <div class="row pb-5">
-    <%# raise 'hell' %>
       <div class="about-col col-xs-12 py-5 <%= current_account.name == "adl" ? "col-sm-4" : "" %>">
         <% if (display_content_block? @homepage_about_section_content).present? %>
           <%= displayable_content_block @homepage_about_section_content, class: '' %>

--- a/app/views/adl/_about_section.html.erb
+++ b/app/views/adl/_about_section.html.erb
@@ -4,7 +4,8 @@
       <%= displayable_content_block @homepage_about_section_heading, class: 'h2' %>
     <% end %>
     <div class="row pb-5">
-      <div class="about-col col-xs-12 col-sm-4 py-5">
+    <%# raise 'hell' %>
+      <div class="about-col col-xs-12 py-5 <%= current_account.name == "adl" ? "col-sm-4" : "" %>">
         <% if (display_content_block? @homepage_about_section_content).present? %>
           <%= displayable_content_block @homepage_about_section_content, class: '' %>
         <% end %>
@@ -13,14 +14,16 @@
           <span class="fa fa-caret-right"></span> 
         <% end %>
       </div>
-      <div class="news-widget-col col-xs-12 col-sm-8 py-5">
-        <h4 class="">Recent News & Updates</h4>
-        <div class= "news-widget-wrapper">
-          <div class="news-widget-scroll">
-            <a class="twitter-timeline" href="https://twitter.com/AdventistDigLib?ref_src=twsrc%5Etfw">Tweets by AdventistDigLib</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+      <% if current_account.name == "adl" %>
+        <div class="news-widget-col col-xs-12 py-5 col-sm-8">
+          <h4 class="">Recent News & Updates</h4>
+          <div class= "news-widget-wrapper">
+            <div class="news-widget-scroll">
+              <a class="twitter-timeline" href="https://twitter.com/AdventistDigLib?ref_src=twsrc%5Etfw">Tweets by AdventistDigLib</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+            </div>
           </div>
         </div>
-      </div>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/views/hyrax/homepage/index.html.erb
+++ b/app/views/hyrax/homepage/index.html.erb
@@ -6,7 +6,11 @@
 
 <div class="home-content">
   <%= render '/adl/about_section' %>
-  <%= render '/adl/featured_collections' %>
+  <%# this conditional hides featured collections in non-adl tenants. fill in your tenant's name, and switch the comments on the following 2 lines to see this section in the development environment %>
+  <%# if current_account.cname == "<YOUR TENANT NAME HERE>" %>
+  <% if current_account.name == "adl" %>
+    <%= render '/adl/featured_collections' %>
+  <% end %>
   <%= render '/adl/featured_works' %>
 </div>
 

--- a/app/views/hyrax/homepage/index.html.erb
+++ b/app/views/hyrax/homepage/index.html.erb
@@ -7,7 +7,7 @@
 <div class="home-content">
   <%= render '/adl/about_section' %>
   <%# this conditional hides featured collections in non-adl tenants. fill in your tenant's name, and switch the comments on the following 2 lines to see this section in the development environment %>
-  <%# if current_account.cname == "<YOUR TENANT NAME HERE>" %>
+  <%# if current_account.name == "<YOUR TENANT NAME HERE>" %>
   <% if current_account.name == "adl" %>
     <%= render '/adl/featured_collections' %>
   <% end %>


### PR DESCRIPTION
# Summary
- this PR conditionally hides the featured collections section from tenants that are not adl
- I checked and the `current_account.name` for adl an prod and it is indeed "adl"
- it also hides the news widget in the about section for non adl tenants, plus adds conditional classes to rearrange the layout of the about section depending on if the news widget shows or not

# Acceptance criteria
- [ ] As a user, I should only see the featured collections section on the adl tenant.
- [ ] As a user, the about section should only show the news widget on the adl tenant.

