### PR TITLE
125 Ability to change header/footer color per tenant

### DIFF
--- a/app/assets/stylesheets/adl-overrides/footer.scss
+++ b/app/assets/stylesheets/adl-overrides/footer.scss
@@ -1,3 +1,8 @@
+// Set the nav background color OUTSIDE of the body tag so that it can be overridden by appearance styles
+.public-facing .navbar.navbar-inverse.site-footer {
+  background: linear-gradient($lightgrey, $mediumyellow);
+}
+
 body.public-facing {
 
   /* prevents footer from covering bottom of page */
@@ -11,7 +16,6 @@ body.public-facing {
   .navbar.navbar-inverse.site-footer {
     font-weight: 600;
     font-size: smaller;
-    background: linear-gradient($lightgrey, $mediumyellow);
     border: none;
     padding: inherit;
     height: auto;

--- a/app/assets/stylesheets/adl-overrides/navbar.scss
+++ b/app/assets/stylesheets/adl-overrides/navbar.scss
@@ -1,9 +1,13 @@
+// Set the nav background color OUTSIDE of the body tag so that it can be overridden by appearance styles
+.public-facing #masthead.navbar.navbar-inverse.navbar-static-top {
+  background: linear-gradient($mediumyellow, rgb(255, 255, 255), $transparentwhite, rgba(255, 255, 255, 0));
+}
+
 body.public-facing {
   // MAIN NAV
 
   #masthead {
     &.navbar.navbar-inverse.navbar-static-top {
-      background: linear-gradient(rgb(206, 140, 0), rgb(255, 255, 255), $transparentwhite, rgba(255, 255, 255, 0));
       height: 150px;
       display: flex;
       width: 100%;

--- a/app/forms/hyrax/forms/admin/appearance.rb
+++ b/app/forms/hyrax/forms/admin/appearance.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # OVERRIDE here to add Adventist's custom color for their header & footer
 
 # rubocop:disable Metrics/ClassLength

--- a/app/forms/hyrax/forms/admin/appearance.rb
+++ b/app/forms/hyrax/forms/admin/appearance.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# OVERRIDE here to add Adventist's custom color for their header & footer
 
 # rubocop:disable Metrics/ClassLength
 module Hyrax
@@ -14,6 +15,7 @@ module Hyrax
           'headline_font' => 'Helvetica Neue, Helvetica, Arial, sans-serif;'
         }.freeze
 
+        # OVERRIDE here to add custom_adl_header_footer_color
         DEFAULT_COLORS = {
           'header_background_color'          => '#000000',
           'header_text_color'                => '#FFFFFF',
@@ -31,7 +33,8 @@ module Hyrax
           'default_button_text_color'        => '#FFFFFF',
           'active_tabs_background_color'     => '#FFFFFF',
           'facet_panel_background_color'     => '#000000',
-          'facet_panel_text_color'           => '#FFFFFF'
+          'facet_panel_text_color'           => '#FFFFFF',
+          'custom_adl_header_footer_color'   => '#CE8C00'
         }.freeze
 
         DEFAULT_VALUES = DEFAULT_FONTS.merge(DEFAULT_COLORS).freeze
@@ -259,7 +262,13 @@ module Hyrax
           end
         end
 
+        # OVERRIDE here to add adventist's custom header & footer
+        def custom_adl_header_footer_color
+          block_for('custom_adl_header_footer_color')
+        end
+
         # A list of parameters that are related to customizations
+        # OVERRIDE here to add custom_adl_header_footer_color
         def self.customization_params
           %i[
             body_font
@@ -282,6 +291,7 @@ module Hyrax
             searchbar_text_color
             searchbar_text_hover_color
             custom_css_block
+            custom_adl_header_footer_color
           ]
         end
 

--- a/app/views/hyrax/admin/appearances/show.html.erb
+++ b/app/views/hyrax/admin/appearances/show.html.erb
@@ -1,3 +1,4 @@
+<%# OVERRIDE to add custom ADL header/footer color to appearance styles %>
 <% provide :page_header do %>
   <h1><span class="fa fa-paint-brush"></span> <%= t('.header') %></h1>
 <% end %>
@@ -133,15 +134,16 @@
               <div class="panel-body defaultable-colors">
                 <% dc = @form.class::DEFAULT_COLORS %>
 
+                <%# OVERRIDE here to add custom ADL header/footer color to appearance styles %>
                 <div class='row'>
                   <div class='col-lg-10'>
-                    <%= f.input :header_background_color, required: false, input_html: { type: 'color', data: { default_value: dc['header_background_color'] } } %>
+                    <%= f.input :custom_adl_header_footer_color, label: "Custom ADL Header & Footer Color", required: false, input_html: { type: 'color', data: { default_value: dc['custom_adl_header_footer_color'] } }  %>
                   </div>
                   <div class='col-lg-2'>
-                    <%= link_to 'Restore Default', '#color', class: 'btn btn-default restore-default-color', data: { default_target: 'header_background_color' } %>
+                    <%= link_to 'Restore Default', '#color', class: 'btn btn-default restore-default-color', data: { default_target: 'custom_adl_header_footer_color' } %>
                   </div>
                 </div>
-
+                <%# OVERRIDE here to remove "header color" to avoid confusion given there is a custom color set up for it %>
                 <div class='row'>
                   <div class='col-lg-10'>
                     <%= f.input :header_text_color, required: false, input_html: { type: 'color', data: { default_value: dc['header_text_color'] } }  %>

--- a/app/views/shared/_appearance_styles.html.erb
+++ b/app/views/shared/_appearance_styles.html.erb
@@ -1,3 +1,5 @@
+<%# OVERRIDE: Add custom header & footer gradients for Adventist Digital Library %>
+
 <% # Dynamic styles added by the admin in the appearances page %>
 <% appearance = Hyrax::Forms::Admin::Appearance.new %>
 <style>
@@ -145,6 +147,15 @@
 }
 .public-facing .panel-default { border-color: <%= appearance.facet_panel_border_color %>; }
 .public-facing .panel-heading.collapse-toggle .panel-title:after { color: <%= appearance.facet_panel_text_color %>; }
+
+
+/* CUSTOM ADVENTIST DIGITAL LIBRARY OVERRIDE COLOR FOR HEADER & FOOTER */
+.public-facing #masthead.navbar.navbar-inverse.navbar-static-top {
+  background: linear-gradient(<%= appearance.custom_adl_header_footer_color %>, #ffffff, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0));
+}
+.public-facing .navbar.navbar-inverse.site-footer {
+    background: linear-gradient(#F5F5F6, <%= appearance.custom_adl_header_footer_color %>);
+}
 
 <%= appearance.custom_css_block %>
 


### PR DESCRIPTION
# Summary
This commit allows the user to update the header & footer gradient color depending on the tenant- In the wireframe discussion with the client, we decided this would be the best path forward to have slightly different design for the SDAPI tenant.

# Related
[Make header & footer colors changeable per tenant](https://github.com/orgs/scientist-softserv/projects/31/views/1)
[Home Page Epic](https://github.com/scientist-softserv/adventist-dl/issues/76)

# Video
https://share.getcloudapp.com/z8ulAW17

# Acceptance Criteria
- [ ] The default color will still be the ADL gold color
- [ ] As a user, I can update a setting in the appearance styles to change the header & footer on each tenant. 