### PR TITLE
Source first in facets + theming tweaks on search results

### DIFF
--- a/app/assets/stylesheets/adl-overrides/adl-overrides.scss
+++ b/app/assets/stylesheets/adl-overrides/adl-overrides.scss
@@ -144,7 +144,7 @@ body.public-facing {
   }
 
   a.btn.btn-danger {
-    color: black !important;
+    color: $black !important;
   }
 
   // Breadcrumbs
@@ -279,6 +279,21 @@ body.public-facing {
   .constraints-container {
     border-radius: 4px;
     background-color: $lightgrey;
+  }
+
+  .search-widgets, #sort-dropdown, #per_page-dropdown {
+    .btn.btn-default {
+      &.view-type-gallery, &.view-type-list, &.view-type-masonry, &.view-type-slideshow, &.dropdown-toggle {
+        border-color: $lightgreyborder;
+        color: $darkgrey;
+      }
+    }
+  }
+
+  .pagination .active span {
+    background-color: $lightgrey;
+    border-color: $lightgreyborder;
+    color: $darkgrey
   }
 
   // Announcement Content Block

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -76,6 +76,7 @@ class CatalogController < ApplicationController
 
     # solr fields that will be treated as facets by the blacklight application
     #   The ordering of the field names is the order of the display
+    config.add_facet_field solr_name("source", :facetable), label: "Source", limit: 5, collapse: false
     config.add_facet_field solr_name("human_readable_type", :facetable), label: "Type", limit: 5, collapse: false
     config.add_facet_field(
       'sorted_year_isi',
@@ -97,7 +98,6 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name("subject", :facetable), limit: 5
     config.add_facet_field solr_name("language", :facetable), limit: 5
     config.add_facet_field solr_name("based_near_label", :facetable), limit: 5
-    config.add_facet_field solr_name("source", :facetable), label: "Source", limit: 5, collapse: false
     config.add_facet_field solr_name("part_of", :facetable), limit: 5
     # config.add_facet_field solr_name("file_format", :facetable), limit: 5
     # config.add_facet_field solr_name("contributor", :facetable), label: "Contributor", limit: 5


### PR DESCRIPTION
# Summary

Source should be first in the facets. also the button text needs to be visible and not white, and buttons on the search results page should be consistent colors

# Related
[Move Source facet in SDAPI search results#41](https://github.com/scientist-softserv/adventist-dl/issues/41)


# Screenshot

Before:
<img width="1321" alt="image" src="https://user-images.githubusercontent.com/73361970/202788657-19fcc59f-5217-4755-8ee7-84b0ac0ef862.png">


After:
<img width="1347" alt="image" src="https://user-images.githubusercontent.com/73361970/202788192-8b5a41a6-86e6-4c30-8973-41d7578e3086.png">
