### PR TITLE
Ensuring we have "all_fields" as part of all fields

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -181,7 +181,8 @@ class CatalogController < ApplicationController
     # solr request handler? The one set in config[:default_solr_parameters][:qt],
     # since we aren't specifying it otherwise.
     config.add_search_field('all_fields', label: 'All Fields', include_in_advanced_search: false) do |field|
-      all_names = config.show_fields.values.map(&:field).join(" ")
+      all_names = (config.show_fields.values.map { |v| v.field.to_s } +
+                   DogBiscuits.config.all_properties.map { |p| "#{p}_tesim" }).uniq.join(" ")
       title_name = solr_name("title", :stored_searchable)
       field.solr_parameters = {
         qf: "#{all_names} file_format_tesim all_text_timv",


### PR DESCRIPTION
**NOTE**: I would like to understand more of what lead to us comment out code; I know I was prodding to remove any DogBiscuits declarations as they cloud the implementation.

Prior to this commit, the "all_names" local variable was an empty string.  This emptiness was the result of @1ceee50 commenting out the following in `app/controllers/catalog_controller.rb`:

```ruby
show_props = DogBiscuits.config.all_properties
add_show_field config, show_props
```

The impact was that this removed almost all fields from the fields in which we searched for values.

With this commit, instead of uncommenting out the code, which may be the more correct pathway, I want to mimic what DogBiscuits was doing with those properties.  In addition, I'm allowing for the potential to declare additional show_fields that are not part of DogBiscuits; at present there are none..

This relates to and would eventually close:

- https://github.com/scientist-softserv/adventist-dl/issues/43
