### PR TITLE
Ensuring metadata_prefix option is correctly passed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,7 +91,7 @@ end
 
 # Bulkrax
 group :bulkrax do
-  gem 'bulkrax', git: 'https://github.com/samvera-labs/bulkrax.git', ref: '329fd99bb5bb79d4fcf1bfdc163ed371457d28a4'
+  gem 'bulkrax', git: 'https://github.com/samvera-labs/bulkrax.git', ref: '89d80df59172a051bef583b812b66e3d57cd70cb'
   gem 'willow_sword', git: 'https://github.com/notch8/willow_sword.git'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/bulkrax.git
-  revision: 329fd99bb5bb79d4fcf1bfdc163ed371457d28a4
-  ref: 329fd99bb5bb79d4fcf1bfdc163ed371457d28a4
+  revision: 89d80df59172a051bef583b812b66e3d57cd70cb
+  ref: 89d80df59172a051bef583b812b66e3d57cd70cb
   specs:
     bulkrax (4.3.0)
       bagit (~> 0.4)


### PR DESCRIPTION
Prior to this commit, the `metadata_prefix` passed on `OAI::Client.new` was discarded.  In the current code, that option is not processed.  It is instead a parameter to pass to the OAI verb
action (e.g. `ListIdentifiers` and `GetRecords`).

With this commit, we ensure that we pass the `metadata_prefix` to the specific verb.

Related to:

- https://github.com/samvera-labs/bulkrax/issues/676
