### PR TITLE
i120 share your work feature

### DIFF
--- a/app/presenters/hyrax/homepage_presenter_decorator.rb
+++ b/app/presenters/hyrax/homepage_presenter_decorator.rb
@@ -6,6 +6,11 @@ module Hyrax
     def display_featured_researcher?
       Flipflop.show_featured_researcher?
     end
+
+    def display_share_button?
+      Flipflop.show_share_button? && current_ability.can_create_any_work? ||
+        Flipflop.show_share_button? && user_unregistered?
+    end
   end
 end
 

--- a/config/features.rb
+++ b/config/features.rb
@@ -2,4 +2,8 @@ Flipflop.configure do
   feature :show_featured_researcher,
           default: false,
           description: "Shows the Featured Researcher tab on the homepage."
-end
+
+          feature :show_share_button,
+          default: true,
+          description: "Shows the 'Share Your Work' button on the homepage."
+ end

--- a/config/features.rb
+++ b/config/features.rb
@@ -3,7 +3,7 @@ Flipflop.configure do
           default: false,
           description: "Shows the Featured Researcher tab on the homepage."
 
-          feature :show_share_button,
+  feature :show_share_button,
           default: true,
           description: "Shows the 'Share Your Work' button on the homepage."
  end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -947,7 +947,7 @@ en:
     select_type:
       description: General purpose worktype
       name: Work
-    share_button: Contribute
+    share_button: Share Your Work
     single_use_links:
       button: Single-Use Link to File
       copy:


### PR DESCRIPTION
Fixes #120

Before this commit: 
The share your work feature flipper was not displayed in the admin dashboard.

After this commit:
The share your work feature flipper is rendered in the admin dashboard.


![image](https://user-images.githubusercontent.com/95306716/203428162-ca57e68b-f537-40b4-b20a-85de3e88645f.png)
