### PR TITLE
Gracefully handling empty records for OAI collection

### DIFF
--- a/app/parsers/bulkrax/oai_adventist_qdc_parser.rb
+++ b/app/parsers/bulkrax/oai_adventist_qdc_parser.rb
@@ -75,7 +75,7 @@ module Bulkrax
       @collections = []
       @works = []
       @file_sets = []
-      if model_field_mappings.map { |mfm| records.first.metadata.find("//#{mfm}").first }.any?
+      if model_field_mappings.map { |mfm| records.first&.metadata&.find("//#{mfm}")&.first }.any?
         records.map do |r|
           model_field_mappings.each do |model_mapping|
             next unless r.metadata.find("//#{model_mapping}").first


### PR DESCRIPTION
Prior to this commit, if the OAI collection had no records we would raise the following exception:

```
NoMethodError: undefined method `metadata' for nil:NilClass
/app/samvera/hyrax-webapp/app/parsers/bulkrax/oai_adventist_qdc_parser.rb:78
```

The problem is that this would silently enter into the retry loop; and would look as though the importer wasn't doing anything as it would continually report as pending.

With this commit, we short-circuit the exception and "gracefully" handle the situation.  I'm unclear if this is this the desired behavior? Should we instead report something?

I put this forward as a potential solution.

