### PR TITLE
Unpinning and upgrading Bulkrax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,7 +91,11 @@ end
 
 # Bulkrax
 group :bulkrax do
-  gem 'bulkrax', "~> 4.4"
+  # Until f48623384d312db4758a36a4dff61dca2e609119 is in a major release, use this ref or a ref
+  # who's ancestors include this ref.
+  # rubocop:disable Metrics/LineLength
+  gem 'bulkrax', "~> 4.4", git: "https://github.com/samvera-labs/bulkrax.git", ref: "f48623384d312db4758a36a4dff61dca2e609119"
+  # rubocop:enable Metrics/LineLength
   gem 'willow_sword', git: 'https://github.com/notch8/willow_sword.git'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -91,7 +91,7 @@ end
 
 # Bulkrax
 group :bulkrax do
-  gem 'bulkrax', git: 'https://github.com/samvera-labs/bulkrax.git', ref: '1f47d49b27371cfa5ba94c7aa1fc6ced56aff316'
+  gem 'bulkrax', "~> 4.4"
   gem 'willow_sword', git: 'https://github.com/notch8/willow_sword.git'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,26 @@ GIT
       rubyzip (>= 1.0.0)
 
 GIT
+  remote: https://github.com/samvera-labs/bulkrax.git
+  revision: f48623384d312db4758a36a4dff61dca2e609119
+  ref: f48623384d312db4758a36a4dff61dca2e609119
+  specs:
+    bulkrax (4.4.0)
+      bagit (~> 0.4)
+      coderay
+      iso8601 (~> 0.9.0)
+      kaminari
+      language_list (~> 1.2, >= 1.2.1)
+      libxml-ruby (~> 3.1.0)
+      loofah (>= 2.2.3)
+      oai (>= 0.4, < 2.x)
+      rack (>= 2.0.6)
+      rails (>= 5.1.6)
+      rdf (>= 2.0.2, < 4.0)
+      rubyzip
+      simple_form
+
+GIT
   remote: https://github.com/samvera-labs/dog_biscuits.git
   revision: 56b3dc7099069b05d3441069910a91ae5726e77c
   specs:
@@ -187,20 +207,6 @@ GEM
       signet (~> 0.8)
       typhoeus
     builder (3.2.4)
-    bulkrax (4.4.0)
-      bagit (~> 0.4)
-      coderay
-      iso8601 (~> 0.9.0)
-      kaminari
-      language_list (~> 1.2, >= 1.2.1)
-      libxml-ruby (~> 3.1.0)
-      loofah (>= 2.2.3)
-      oai (>= 0.4, < 2.x)
-      rack (>= 2.0.6)
-      rails (>= 5.1.6)
-      rdf (>= 2.0.2, < 4.0)
-      rubyzip
-      simple_form
     byebug (11.1.3)
     cancancan (1.17.0)
     capybara (3.33.0)
@@ -1104,7 +1110,7 @@ DEPENDENCIES
   blacklight_oai_provider (~> 6.1, >= 6.1.1)
   blacklight_range_limit (= 6.5.0)
   bootstrap-datepicker-rails
-  bulkrax (~> 4.4)
+  bulkrax (~> 4.4)!
   byebug
   capybara
   carrierwave-aws (~> 1.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,26 +8,6 @@ GIT
       rubyzip (>= 1.0.0)
 
 GIT
-  remote: https://github.com/samvera-labs/bulkrax.git
-  revision: 1f47d49b27371cfa5ba94c7aa1fc6ced56aff316
-  ref: 1f47d49b27371cfa5ba94c7aa1fc6ced56aff316
-  specs:
-    bulkrax (4.3.0)
-      bagit (~> 0.4)
-      coderay
-      iso8601 (~> 0.9.0)
-      kaminari
-      language_list (~> 1.2, >= 1.2.1)
-      libxml-ruby (~> 3.1.0)
-      loofah (>= 2.2.3)
-      oai (>= 0.4, < 2.x)
-      rack (>= 2.0.6)
-      rails (>= 5.1.6)
-      rdf (>= 2.0.2, < 4.0)
-      rubyzip
-      simple_form
-
-GIT
   remote: https://github.com/samvera-labs/dog_biscuits.git
   revision: 56b3dc7099069b05d3441069910a91ae5726e77c
   specs:
@@ -207,6 +187,20 @@ GEM
       signet (~> 0.8)
       typhoeus
     builder (3.2.4)
+    bulkrax (4.4.0)
+      bagit (~> 0.4)
+      coderay
+      iso8601 (~> 0.9.0)
+      kaminari
+      language_list (~> 1.2, >= 1.2.1)
+      libxml-ruby (~> 3.1.0)
+      loofah (>= 2.2.3)
+      oai (>= 0.4, < 2.x)
+      rack (>= 2.0.6)
+      rails (>= 5.1.6)
+      rdf (>= 2.0.2, < 4.0)
+      rubyzip
+      simple_form
     byebug (11.1.3)
     cancancan (1.17.0)
     capybara (3.33.0)
@@ -1110,7 +1104,7 @@ DEPENDENCIES
   blacklight_oai_provider (~> 6.1, >= 6.1.1)
   blacklight_range_limit (= 6.5.0)
   bootstrap-datepicker-rails
-  bulkrax!
+  bulkrax (~> 4.4)
   byebug
   capybara
   carrierwave-aws (~> 1.3)


### PR DESCRIPTION
Prior to this commit, we needed [Bulrax's 1f47d49b commit][1], which was not in a released version.

With this commit, we're leveraging Bulkrax v4.4.0 which contains the [1f47d49b][1] commit.  See below.

```shell
$ cd ~/git/bulkrax
$ git checkout main; git pull main
$ git tag --contains 1f47d49b27371cfa5ba94c7aa1fc6ced56aff316
v4.4.0
```

Possibly related to #179 

[1]: https://github.com/samvera-labs/bulkrax/commit/1f47d49b27371cfa5ba94c7aa1fc6ced56aff316

@samvera/hyku-code-reviewers
