### PR TITLE
Ensuring that the OAI records are an array

### DIFF
--- a/app/parsers/bulkrax/oai_adventist_qdc_parser.rb
+++ b/app/parsers/bulkrax/oai_adventist_qdc_parser.rb
@@ -92,7 +92,12 @@ module Bulkrax
         end
         flatten_arrays(%w[@collections @file_sets @works])
       else # if no model is specified, assume all records are works
-        @works = records
+        # @see https://github.com/scientist-softserv/adventist-dl/issues/208
+        #
+        # In this case `records` is a "OAI::ListRecordsResponse" object which is an Enumerable but
+        # does not respond to flatten.  By using Array() we convert the records object into an actual
+        # array.
+        @works = Array(records)
         flatten_arrays(%w[@works])
       end
       true


### PR DESCRIPTION
Prior to this commit, we were attempting to call flatten on a [Oai::ListRecordsResponse][1] object.  That object is an `Enumerable` which is why we can call `#map` on the object.  However, `#flatten` is not a defacto method on an `Enumerable` object.

With this commit, we're using the `Array()` function to coerce the `Oai::ListRecordsResponse` into an Array.  Under the hood, the `Array()` calls the `#each` method of an Enumerable.

Below is a proof of concept for the solution.  Notice that the `Thing#each` converts the internal array.  Much like `Oai::ListRecordsResponse` does in it's implementation.

```ruby
class Thing
  include Enumerable
  def initialize(*args)
    @elements = *args
  end

  def each
    @elements.each do |e|
      yield "Value: #{e.inspect}"
    end
  end
end

thing = Thing.new(:a,:b,:c)

puts Array(thing).flatten.inspect
=> ["Value: :a", "Value: :b", "Value: :c"]

thing.flatten
=> undefined method `flatten' for #<Thing:0x00000001007a25a0 @elements=[:a, :b, :c]> (NoMethodError)
```

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/208

[1]: https://github.com/code4lib/ruby-oai/blob/d0303be9800e7247532286330cf3b0cf135f19d7/lib/oai/client/list_records.rb#L1-L22
