### PR TITLE
Bumping hyrax to address silent infinite retries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,10 +91,10 @@ end
 
 # Bulkrax
 group :bulkrax do
-  # Until f48623384d312db4758a36a4dff61dca2e609119 is in a major release, use this ref or a ref
+  # Until d36cf3606545ea30da8d8082f1b67b96d9aaf8c1 is in a major release, use this ref or a ref
   # who's ancestors include this ref.
   # rubocop:disable Metrics/LineLength
-  gem 'bulkrax', "~> 4.4", git: "https://github.com/samvera-labs/bulkrax.git", ref: "f48623384d312db4758a36a4dff61dca2e609119"
+  gem 'bulkrax', "~> 4.4", git: "https://github.com/samvera-labs/bulkrax.git", ref: "d36cf3606545ea30da8d8082f1b67b96d9aaf8c1"
   # rubocop:enable Metrics/LineLength
   gem 'willow_sword', git: 'https://github.com/notch8/willow_sword.git'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/bulkrax.git
-  revision: f48623384d312db4758a36a4dff61dca2e609119
-  ref: f48623384d312db4758a36a4dff61dca2e609119
+  revision: d36cf3606545ea30da8d8082f1b67b96d9aaf8c1
+  ref: d36cf3606545ea30da8d8082f1b67b96d9aaf8c1
   specs:
     bulkrax (4.4.0)
       bagit (~> 0.4)


### PR DESCRIPTION
From the Bulkrax pull request:

> Prior to this commit, when we encountered a
> `Bulkrax::CollectionsCreatedError`, we would reschedule the same job
> with a 1 minute delay.  However, if the underlying issue was never
> resolved, we would continually reschedule without fanfare this failing
> job.
>
> With this commit, we provide 3 logged reschedules, then if that fails
> we raise an exception break the infinite cycle.  By breaking the
> cycle, then the upstream Sidekiq handler can determine if it should be
> thrown into the `Retry` queue (where the jobs that raise exceptions
> go).
>
> We discovered this in Adventist watch 100 or scheduled jobs run very
> fast, and apparently continually rescheduling themselves.

Related to:

- https://github.com/samvera-labs/bulkrax/pull/692
- https://github.com/samvera-labs/bulkrax/issues/691

