### PR TITLE
Capturing raw metadata for OAI parsing of works

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,10 +91,10 @@ end
 
 # Bulkrax
 group :bulkrax do
-  # Until d36cf3606545ea30da8d8082f1b67b96d9aaf8c1 is in a major release, use this ref or a ref
+  # Until d1d0eca5963fcd190955ab75bcf9d0285afa2bb2 is in a major release, use this ref or a ref
   # who's ancestors include this ref.
   # rubocop:disable Metrics/LineLength
-  gem 'bulkrax', "~> 4.4", git: "https://github.com/samvera-labs/bulkrax.git", ref: "d36cf3606545ea30da8d8082f1b67b96d9aaf8c1"
+  gem 'bulkrax', "~> 4.4", git: "https://github.com/samvera-labs/bulkrax.git", ref: "d1d0eca5963fcd190955ab75bcf9d0285afa2bb2"
   # rubocop:enable Metrics/LineLength
   gem 'willow_sword', git: 'https://github.com/notch8/willow_sword.git'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/bulkrax.git
-  revision: d36cf3606545ea30da8d8082f1b67b96d9aaf8c1
-  ref: d36cf3606545ea30da8d8082f1b67b96d9aaf8c1
+  revision: d1d0eca5963fcd190955ab75bcf9d0285afa2bb2
+  ref: d1d0eca5963fcd190955ab75bcf9d0285afa2bb2
   specs:
     bulkrax (4.4.0)
       bagit (~> 0.4)


### PR DESCRIPTION
Prior to this commit, we didn't capture the raw metadata of works parsed via OAI-PMH.

## From the Bulkrax change:

With this change, we now capture that information.

Below is an example showing that we need to use the record's `metadata` as a string.

```ruby
gem "oai"
require 'oai'
client = OAI::Client.new(
  "http://oai.adventistdigitallibrary.org/OAI-script",
  headers: { from: "jeremy@scientist.com" },
  parser: 'libxml')

opts = {
  metadata_prefix: "oai_adl",
  set: "adl:issue"
}

records = client.list_records(opts)

records.each_with_index do |r, i|
  puts "Working on record ##{i+1}"
  puts "Metadata:\n#{r.metadata.to_s}"
end
```

Related to: samvera-labs/bulkrax#694
