### PR TITLE
Fixing bug in metadata capture for OAI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,10 +91,10 @@ end
 
 # Bulkrax
 group :bulkrax do
-  # Until d1d0eca5963fcd190955ab75bcf9d0285afa2bb2 is in a major release, use this ref or a ref
+  # Until b857a25becefc4bd960f25647033dfb2e899386e is in a major release, use this ref or a ref
   # who's ancestors include this ref.
   # rubocop:disable Metrics/LineLength
-  gem 'bulkrax', "~> 4.4", git: "https://github.com/samvera-labs/bulkrax.git", ref: "d1d0eca5963fcd190955ab75bcf9d0285afa2bb2"
+  gem 'bulkrax', "~> 4.4", git: "https://github.com/samvera-labs/bulkrax.git", ref: "b857a25becefc4bd960f25647033dfb2e899386e"
   # rubocop:enable Metrics/LineLength
   gem 'willow_sword', git: 'https://github.com/notch8/willow_sword.git'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/bulkrax.git
-  revision: d1d0eca5963fcd190955ab75bcf9d0285afa2bb2
-  ref: d1d0eca5963fcd190955ab75bcf9d0285afa2bb2
+  revision: b857a25becefc4bd960f25647033dfb2e899386e
+  ref: b857a25becefc4bd960f25647033dfb2e899386e
   specs:
     bulkrax (4.4.0)
       bagit (~> 0.4)


### PR DESCRIPTION
> Moving OAI metadata capture to entry processing
>
> In writing samvera-labs/bulkrax#694 I introduced an OAI bug.  There
> are two OAI fetch cycles.
>
>The first is the list of records.  These are fetched via the
>`list_identifiers` method.  That method returns header information
>without metadata.  Then, we submit one job per header.  At that point
>we perform the second fetch of the record.  This includes the full
>metadata.

Related to:

- samvera-labs/bulkrax#697
- samvera-labs/bulkrax#694
- #211
