### PR TITLE
Introduce memoization and better default

### DIFF
--- a/app/parsers/bulkrax/oai_adventist_qdc_parser.rb
+++ b/app/parsers/bulkrax/oai_adventist_qdc_parser.rb
@@ -65,10 +65,7 @@ module Bulkrax
     end
 
     def model_field_mappings
-      model_mappings = Bulkrax.field_mappings[self.class.to_s]&.dig('model', :from) || []
-      model_mappings ||= ['model']
-
-      model_mappings
+      @model_field_mappings ||= Bulkrax.field_mappings[self.class.to_s]&.dig('model', :from) || ["model"]
     end
 
     def build_records


### PR DESCRIPTION
Prior to this commit, we were looping through records and calling model_field_mappings; each time we regenerated the array.  In addition the `model_mappings ||= ['model']` would never be set because before that we guaranteed that `model_mappings` was at least `[]`

With this commit, we both memoize the results and set the initial intended default value.
