### PR TITLE
Updating OAI parsing for Adventist based on assumptions

### DIFF
--- a/app/models/bulkrax/oai_adventist_set_entry.rb
+++ b/app/models/bulkrax/oai_adventist_set_entry.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
 module Bulkrax
-  class OaiAdventistQdcEntry < OaiQualifiedDcEntry
+  class OaiAdventistSetEntry < OaiSetEntry
     # override to swap out the thumbnail_url
     def build_metadata
       self.parsed_metadata = {}
+      # rubocop:disable Style/RedundantSelf
+      #
+      # Yes I could favor `parsed_metadata[work_identifier]` however in the above line, we use
+      # `self.` And so as to maintain the visual cues of "these are the same symbols" I'm choosing
+      # to disable the RedundantSelf cop for this method.
       self.parsed_metadata[work_identifier] = [record.header.identifier]
       self.raw_metadata = { record_level_xml: record._source.to_s }
 
@@ -14,14 +19,11 @@ module Bulkrax
         end
       end
 
-      add_visibility
-      add_rights_statement
-      add_admin_set_id
-      add_collections
       # see app/models/concerns/bulkrax/has_local_processing.rb
       add_local
 
       self.parsed_metadata
+      # rubocop:enable Style/RedundantSelf
     end
   end
 end

--- a/app/models/bulkrax/oai_adventist_set_entry.rb
+++ b/app/models/bulkrax/oai_adventist_set_entry.rb
@@ -2,7 +2,6 @@
 
 module Bulkrax
   class OaiAdventistSetEntry < OaiSetEntry
-    # override to swap out the thumbnail_url
     def build_metadata
       self.parsed_metadata = {}
       # rubocop:disable Style/RedundantSelf
@@ -18,6 +17,13 @@ module Bulkrax
           add_metadata(node.name, node.content)
         end
       end
+
+      # Note: as of the time of writing this comment, the Bulkrax::OaiSetEntry does not handle
+      # metadata nor does it do anything with visibility, rights statements, or admin sets.  This is
+      # added as an override that I'd love to see "removed"
+      add_visibility
+      add_rights_statement
+      add_admin_set_id
 
       # see app/models/concerns/bulkrax/has_local_processing.rb
       add_local

--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -6,18 +6,12 @@ module Bulkrax
     # add any special processing here, for example to reset a metadata property
     # to add a custom property from outside of the import data
     def add_local
-      if self.parsed_metadata['model'] == 'Collection'
+      if self.parsed_metadata['model'] == 'Collection' || factory_class == Collection
         add_collection_nesting
       else
         add_part_of_collections if self.parsed_metadata['part_of'].present?
-        add_set_collections if self.parsed_metadata['resource_type']&.include?('Issue')
+        add_set_collections
       end
-    end
-
-    def add_collection_ids_from_set
-      sets = record.header.set_spec.map(&:content)
-      self.collection_ids += sets.map { |set| importerexporter.unique_collection_identifier(set) }
-      self.collection_ids = self.collection_ids.uniq
     end
 
     def add_set_collections

--- a/app/parsers/bulkrax/oai_adventist_qdc_parser.rb
+++ b/app/parsers/bulkrax/oai_adventist_qdc_parser.rb
@@ -103,7 +103,7 @@ module Bulkrax
     def dispatch_creating_of_work_objects
       return true if @repository_objects_were_dispatched
 
-      # The records.full call ensures that we leverage the pagination/resumption mechanisms of OIA
+      # The records.full call ensures that we leverage the pagination/resumption mechanisms of OAI
       # (via Ruby's OAI gem).  We choose #each so that we only load in memory each page's records.
       # Were we to choose #map, we would load all records into memory.
       records.full.each_with_index do |record, index|

--- a/app/parsers/bulkrax/oai_adventist_qdc_parser.rb
+++ b/app/parsers/bulkrax/oai_adventist_qdc_parser.rb
@@ -37,10 +37,7 @@ module Bulkrax
       super
       @count_towards_limit = 0
       @counters = { file_set: 0, collection: 0, work: 0 }
-      @model_field_mappings = Bulkrax.field_mappings[self.class.to_s]&.dig('model', :from) || ["model"]
     end
-
-    attr_reader :model_field_mappings
 
     # @see #initialize
     #
@@ -51,7 +48,7 @@ module Bulkrax
 
     # @see #initialize
     attr_accessor :count_towards_limit
-    private :counters, :counters=, :count_towards_limit, :count_towards_limit=, :model_field_mappings
+    private :counters, :counters=, :count_towards_limit, :count_towards_limit=
 
     # @note Included for previous API compatibility.
     def create_collections

--- a/app/parsers/bulkrax/oai_adventist_qdc_parser.rb
+++ b/app/parsers/bulkrax/oai_adventist_qdc_parser.rb
@@ -1,132 +1,216 @@
 # frozen_string_literal: true
 
 module Bulkrax
+  # **Assumption 1 regarding Adventist's OAI feed:** The works, collections, and file sets are declared
+  # at the OAI record level data.
+  #
+  # **Assumption 2 regarding Adventist's OAI feed:** The operator will run the OAI's set(s) that
+  # contain collections before those collections are declared/referenced in other works.  Due to the
+  # asynchronous nature of the entry jobs this means that an importer job (or jobs) should be run
+  # for sets that define the collections; then the importer job(s) should be run for works and file
+  # sets.  If in the future we find that there is a mixture of collection, work, and file set
+  # objects with an OAI feed we might want to consider parameterizing the importer to say
+  # "collections" or not "collections" and then add conditionals accordingly.
+  #
+  # From these assumptions we need to be mindful that our collection creation is different than
+  # other OAI collection creations.
   class OaiAdventistQdcParser < OaiQualifiedDcParser
     def entry_class
       Bulkrax::OaiAdventistQdcEntry
     end
 
+    alias work_entry_class entry_class
+
     def collection_entry_class
-      OaiSetEntry
+      Bulkrax::OaiAdventistSetEntry
     end
 
     def file_set_entry_class
       RdfFileSetEntry
     end
 
+    # Setting both #count_towards_limit and #counters as part of initialization so that regardless
+    # of how we create the objects (e.g. either sequentially calling #create_collections,
+    # #create_file_sets, #create_works, #create_relationships OR calling #create_objects) we
+    # adequately handle the various counts.
+    def initialize(*args, &block)
+      super
+      @count_towards_limit = 0
+      @counters = { file_set: 0, collection: 0, work: 0 }
+      @model_field_mappings = Bulkrax.field_mappings[self.class.to_s]&.dig('model', :from) || ["model"]
+    end
+
+    attr_reader :model_field_mappings
+
+    # @see #initialize
+    #
+    # Because of the assumptions outlined in the class declaration, we are processing a mixture of
+    # file_set, collection, and work types.  Thus we can't rely on the index as we have in other
+    # parser implementations.  Instead we'll
+    attr_accessor :counters
+
+    # @see #initialize
+    attr_accessor :count_towards_limit
+    private :counters, :counters=, :count_towards_limit, :count_towards_limit=, :model_field_mappings
+
+    # @note Included for previous API compatibility.
     def create_collections
       create_objects(['collection'])
     end
 
+    # @note Included for previous API compatibility.
     def create_file_sets
       create_objects(['file_set'])
     end
 
+    # @note Included for previous API compatibility.
+    def create_works
+      create_objects(['work'])
+    end
+
+    # @note Included for previous API compatibility.
     def create_relationships
-      ScheduleRelationshipsJob.set(wait: 5.minutes).perform_later(importer_id: importerexporter.id)
+      create_objects(['relationship'])
     end
 
+    # @note With Bulkrax v4.4.0 we leverage the #create_objects method; in part because we want to
+    #       better handle limits.
+    # @param types_array [Array<String>]
     def create_objects(types_array = nil)
-      index = 0
-      (types_array || %w[collection work file_set relationship]).each do |type|
-        if type.eql?('relationship')
-          ScheduleRelationshipsJob.set(wait: 5.minutes).perform_later(importer_id: importerexporter.id)
-          next
-        elsif type.eql?('work')
-          create_works
-          next
-        end
-        send(type.pluralize).each do |current_record|
-          next unless record_has_source_identifier(current_record, index)
-          break if limit_reached?(limit, index)
-
-          seen[current_record[source_identifier]] = true
-          create_entry_and_job(current_record, type)
-          increment_counters(index, "#{type}": true)
-          index += 1
-        end
-        importer.record_status
+      types_array ||= Bulkrax::Importer::DEFAULT_OBJECT_TYPES
+      types_array.each do |type|
+        send("dispatch_creating_of_#{type}_objects")
       end
-      true
-    rescue StandardError => e
-      status_info(e)
+      importer.record_status
     end
 
-    def create_entry_and_job(current_record, type)
-      new_entry = find_or_create_entry(send("#{type}_entry_class"),
-                                       current_record[source_identifier],
-                                       'Bulkrax::Importer',
-                                       current_record.to_h)
-      if current_record[:delete].present?
-        "Bulkrax::Delete#{type.camelize}Job".constantize.send(perform_method, new_entry, current_run)
+    def dispatch_creating_of_relationship_objects
+      return true if @relationship_was_dispatched
+
+      ScheduleRelationshipsJob.set(wait: 5.minutes).perform_later(importer_id: importerexporter.id)
+      @relationship_was_dispatched = true
+    end
+
+    # In the adventist parser, we process the full records (e.g. OAI's listRecords).  To
+    # understand why we must contrast this with the Bulkrax OAI parser.
+    #
+    # In the Bulkrax OIA parser we process the identifiers (e.g. OAI's listIdentifiers).  The
+    # limitation on the identifiers is that we can't "sniff" what type of object it is (e.g. work,
+    # collection, or file_set).
+    #
+    # Due to the assumptions outlined in the class definition, namely that collections, works, and
+    # file_sets are defined within the record's metadata (e.g. the XML node work_type), we process
+    # the listRecords so we can "sniff" out the appropriate entity type.
+    #
+    # @return [Integer] the number of objects we processed
+    def dispatch_creating_of_work_objects
+      return true if @repository_objects_were_dispatched
+
+      # The records.full call ensures that we leverage the pagination/resumption mechanisms of OIA
+      # (via Ruby's OAI gem).  We choose #each so that we only load in memory each page's records.
+      # Were we to choose #map, we would load all records into memory.
+      records.full.each_with_index do |record, index|
+        break if limit_reached?(limit, count_towards_limit)
+        handle_creation_of(record: record, index: index)
+        self.count_towards_limit += 1
+      end
+
+      @repository_objects_were_dispatched = true
+    end
+
+    # @see the note associated with the #dispatch_creating_of_work_objects method
+    alias dispatch_creating_of_collection_objects dispatch_creating_of_work_objects
+
+    # @see the note associated with the #dispatch_creating_of_work_objects method
+    alias dispatch_creating_of_file_set_objects dispatch_creating_of_work_objects
+
+    # @param record [Oai::Record]
+    # @param index [Integer] the index/position of the Oai::Record in the OAI feed.
+    def handle_creation_of(record:, index:)
+      return false unless record_has_source_identifier(record, index)
+
+      # Given the specificity and standards of an Oai::Record; I'm using this as the identifier.
+      # I'm not looking to the mapping file.
+      identifier = record.header.identifier
+      seen[identifier] = true
+
+      # We need the type for two considerations:
+      #
+      # - What's the entry class
+      # - What's the counter to increment
+      entry_class_type = entry_class_type_for(record: record)
+
+      entry_class = send("#{entry_class_type}_entry_class")
+
+      # We want to find or create the entry based on non-volatile information.  Then we want to
+      # capture the raw metadata for the record; capturing the raw metadata helps in debugging the
+      # object.
+      new_entry = entry_class.where(importerexporter: importerexporter, identifier: identifier).first_or_create!
+      new_entry.update(raw_metadata: { record_level_xml: record._source.to_s })
+
+      # Note the parameters of the delete job and the import jobs are different.  One assumes an
+      # object the other assumes ids.
+      if record.deleted?
+        "bulkrax/delete_#{entry_class_type}_job"
+          .classify
+          .constantize
+          .send(perform_method, new_entry, importerexporter.current_run)
       else
-        "Bulkrax::Import#{type.camelize}Job".constantize.send(perform_method, new_entry.id, current_run.id)
+        "bulkrax/import_#{entry_class_type}_job"
+          .classify
+          .constantize
+          .send(perform_method, new_entry.id, importerexporter.current_run.id)
       end
+
+      increment_counters(index, entry_class_type => counters.fetch(entry_class_type))
+
+      # Why am I incrementing the counters after we call increment_counters?  Because in
+      # {#increment_counters} implementation we add 1 to the counter value.  Why do we add 1?
+      # Because in other implementations that call {#increment_counters} they use a positional index
+      # of the object in the array (e.g. we use #each_with_index and the yielded index as the
+      # counter).
+      #
+      # And we can't use the positional index because the we have a heterogenious set of
+      # entry_class_types tracked on that same index.
+      counters[entry_class_type] += 1
     end
 
-    def model_field_mappings
-      @model_field_mappings ||= Bulkrax.field_mappings[self.class.to_s]&.dig('model', :from) || ["model"]
+    # @param record [Oai::Record]
+    # @param index [Integer] the positional index of the record in the OAI feed.
+    # @return [TrueClass] when we have an identifier.
+    # @return [FalseClass] when we do not have an identifier.
+    #
+    # @note This method deviates from Bulkrax's implemtation in that it's unclear how the OAI object
+    #       would not have an identifier.
+    #
+    # @see Bulkrax::ApplicationParser#record_has_source_identifier
+    def record_has_source_identifier(record, index)
+      # Given the specificity and standards of an Oai::Record; I'm using this as the identifier.
+      # I'm not looking to the mapping file.
+      return true if record.header.identifier.present?
+
+      invalid_record("Missing #{source_identifier} at index #{index} with source #{record._source}\n")
+      false
     end
 
-    # Don't worry rubocop, I'm angling to refactor this to mind our ABCs
-    # rubocop:disable Metrics/AbcSize
-    def build_records
-      @collections = []
-      @works = []
-      @file_sets = []
-      if model_field_mappings.map { |mfm| records.first&.metadata&.find("//#{mfm}")&.first }.any?
-        records.map do |r|
-          model_field_mappings.each do |model_mapping|
-            next unless r.metadata.find("//#{model_mapping}").first
-
-            capture_set_specs_for_collections r.header.set_spec if r.header.set_spec.present?
-            if r.metadata.find("//#{model_mapping}").first.content.casecmp('collection').zero?
-              @collections << r
-            elsif r.metadata.find("//#{model_mapping}").first.content.casecmp('fileset').zero?
-              @file_sets << r
-            else
-              @works << r
-            end
-          end
+    # @param record [Oai::Record]
+    # @return [Symbol] either :collection, :file_set, or :work
+    def entry_class_type_for(record:)
+      entry_class_type = nil
+      model_field_mappings.each do |model_mapping|
+        record_entry_class_type = record.metadata.find("//#{model_mapping}").first&.content || ""
+        if record_entry_class_type.casecmp('collection').zero?
+          entry_class_type = :collection
+          break
+        elsif record_entry_class_type.casecmp('fileset').zero?
+          entry_class_type = :file_set
+          break
+        elsif record_entry_class_type.casecmp('file_set').zero?
+          entry_class_type = :file_set
+          break
         end
-        @collections = @collections.flatten.compact.uniq
-        @file_sets = @file_sets.flatten.compact.uniq
-        @works = @works.flatten.compact.uniq
-      else # if no model is specified, assume all records are works
-        # @see https://github.com/scientist-softserv/adventist-dl/issues/208
-        #
-        # In this case `records` is a "OAI::ListRecordsResponse" object which is an Enumerable but
-        # does not respond to flatten.  By using Array() we convert the records object into an actual
-        # array.
-        @works = Array(records).flatten.compact.uniq
       end
-      true
-    end
-    # rubocop:enable Metrics/AbcSize
-
-    def capture_set_specs_for_collections(set_spec)
-      set_spec.each do |set|
-        @collections << { source_identifier => [importerexporter.unique_collection_identifier(set.content)],
-                          'title' => [importerexporter.unique_collection_identifier(set.content)] }
-      end
-    end
-
-    def works
-      build_records if @works.nil?
-      @works
-    end
-
-    def file_sets
-      build_records if @file_sets.nil?
-      @file_sets
-    end
-
-    def works_total
-      works.size
-    end
-
-    def file_sets_total
-      file_sets.size
+      entry_class_type || :work
     end
   end
 end


### PR DESCRIPTION
## Updating OAI parsing for Adventist based on assumptions

49331b42fefdb62dbceaa852c2498312ebea6709

Prior to this commit, the logic for the Adventist OAI parsing was a
hybrid of CSV and OAI parsing logic.  The parser logic had faulty
assumptions.

In addition, the `Bulkrax::OaiAdventistQdcEntry` introduced logic that
created collections based on the OAI set.  However, based on the OAI
implementation we should only be creating collections when the set has
an AARK ID.  In the prior implementation we were creating a collection
for with the effective title of `adl:periodical`; and that is not a
desired nor intended collection.

With this commit, the core logic better aligns with the outlined
assumptions in the code comments and the OAI feed implementation.  I
have made efforts to document intention (via inline comments) and how it
relates to the foibles of Adventist's OAI implementation.

**What's Not Included**

I have taken efforts to properly address the parser's counts/totals but
these things are quite challening given their upstream Bulkrax
implementation.  In other words expect the following counts to not show
the correct summary totals.

- Total Works
- Total Collections
- Total File Set

Further, I have not addressed the collection's thumbnails.  There is
custom logic for uploading an image to a collection.  I have written
[Issue scientist-softserv/adventist_knapsack#567][223] to track this functionality; [PR scientist-softserv/adventist-dl#131][131] relates to
this issue.

**Related to:**

- https://github.com/scientist-softserv/adventist_knapsack/issues/569
- https://github.com/scientist-softserv/adventist_knapsack/issues/579
- https://github.com/scientist-softserv/adventist_knapsack/issues/578
- https://github.com/scientist-softserv/adventist_knapsack/issues/577
- https://github.com/scientist-softserv/adventist_knapsack/issues/576
- https://github.com/scientist-softserv/adventist_knapsack/issues/567

[131]: https://github.com/scientist-softserv/adventist-dl/pull/131

[223]: https://github.com/scientist-softserv/adventist-dl/issue/223
