### PR TITLE
Restored the metadata on the search page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -108,10 +108,10 @@ class CatalogController < ApplicationController
     # handler defaults, or have no facets.
     config.add_facet_fields_to_solr_request!
 
-    # index_props = DogBiscuits.config.index_properties.collect do |prop|
-    #   { prop => index_options(prop, DogBiscuits.config.property_mappings[prop]) }
-    # end
-    # add_index_field config, index_props
+    index_props = DogBiscuits.config.index_properties.collect do |prop|
+      { prop => index_options(prop, DogBiscuits.config.property_mappings[prop]) }
+    end
+    add_index_field config, index_props
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display


### PR DESCRIPTION
Fixes #177;
Prior to this commit, the metadata would not show on the search results page.

![image](https://user-images.githubusercontent.com/95306716/210446533-51a4038d-1f95-4c19-b593-e76d317e7d35.png)

After this commit, the metadata is restored on the search results page.

![image](https://user-images.githubusercontent.com/95306716/210446431-d6045e97-503d-435e-8dd3-971c9bc042f9.png)

Changes proposed in this pull request:
* Brought the metadata back to the search page by reverting the changes made by a previous ticket
