### PR TITLE
Made edit to show page to hide created by under the title

### DIFF
--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -35,9 +35,7 @@
               <b><%= @presenter.total_viewable_items %></b>
               <%= 'Item'.pluralize(@presenter.total_viewable_items) %></div>
 
-            <% unless @presenter.creator.blank? %>
-                <div class="hyc-created-by">Created by: <%= @presenter.creator.first %></div>
-            <% end %>
+
             <% unless @presenter.modified_date.blank? %>
                 <div class="hyc-last-updated">Last Updated: <%= @presenter.modified_date %></div>
             <% end %>


### PR DESCRIPTION
Fixes [#]https://github.com/scientist-softserv/adventist-dl/issues/51;
Prior to this commit, “created by” shows on the collection page under the title.

![image](https://user-images.githubusercontent.com/95306716/210452026-3d8244f6-6efd-4fdf-a3f4-8450c14667df.png)


After this commit, “created by” has been removed from the collection page under the title.
![image](https://user-images.githubusercontent.com/95306716/210451670-b22bb86f-4d83-4801-a703-b02526d7df8b.png)