### PR TITLE
Removing duplication of `related_url` OAI parsing

### DIFF
--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -59,7 +59,6 @@ if Settings.bulkrax.enabled
         'date_created' => { from:  ['date_created'] },
         'title' => { from:  ['title'] },
         'subject' => { from:  ['subject'] },
-        'related_url' => { from:  ['related_url'] },
         'volume_number' => { from:  ['volume_number'] },
         'keyword' => { from: ['keyword'], split: ';' },
         'location' => { from: ['location'], split: ';' },


### PR DESCRIPTION
Prior to this commit there were two OAI parsing declarations for `related_url`:

- `'related_url' => { from:  ['related_url'] },`
- `'remote_files' => { from: ['related_url'], split: ';', parsed: true },`

Per the logic of the [`Bulkrax::HasMatchers#field_to`][1], this meant we both created related_url metadata and imported the related_url as remote_files.  I wrote about the nuances of this metadata as inline comments in the [AdventistMetadata module][2] (which was added via @d1a9552a9b893ad54f6ff3e8a434905f38f39d82).

This is evident in the results of importing [this work][3].  There is both related_url metadata and attached remote files.

With this commit, we're removing the parsing of `related_url` to `related_url` and keeping the parsing to `remote_files`.  This means that after the change, OAI imports will no longer have the record level related_url metadata.

Related to:

- #201
- #128
- #87

[1]: https://github.com/samvera-labs/bulkrax/blob/0a644637260378ac25fd9e3d4b2e68addb2b3ade/app/models/concerns/bulkrax/has_matchers.rb#L167-L180

[2]: https://github.com/scientist-softserv/adventist-dl/blob/893c189bcaf0eee8bd0438ffca2102081f7570b1/app/models/adventist_metadata.rb#L40-L45

[3]: https://adl.b2.adventistdigitallibrary.org/concern/published_works/20121647_testimony_for_the_church_number_17?locale%3Den&sa=D&source=editors&ust=1671480230567072&usg=AOvVaw1xB8GjqXPGrZP_UW25IKXU
