### PR TITLE
Favoring upstream `Bulkrax::OaiQualifiedDcEntry`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,7 +94,7 @@ group :bulkrax do
   # Until b857a25becefc4bd960f25647033dfb2e899386e is in a major release, use this ref or a ref
   # who's ancestors include this ref.
   # rubocop:disable Metrics/LineLength
-  gem 'bulkrax', "~> 4.4", git: "https://github.com/samvera-labs/bulkrax.git", ref: "b857a25becefc4bd960f25647033dfb2e899386e"
+  gem 'bulkrax', "~> 4.4", git: "https://github.com/samvera-labs/bulkrax.git", ref: "35970cee7b1e48d00c3fc838d2ca5790c09e2c9c"
   # rubocop:enable Metrics/LineLength
   gem 'willow_sword', git: 'https://github.com/notch8/willow_sword.git'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/bulkrax.git
-  revision: b857a25becefc4bd960f25647033dfb2e899386e
-  ref: b857a25becefc4bd960f25647033dfb2e899386e
+  revision: 35970cee7b1e48d00c3fc838d2ca5790c09e2c9c
+  ref: 35970cee7b1e48d00c3fc838d2ca5790c09e2c9c
   specs:
     bulkrax (4.4.0)
       bagit (~> 0.4)

--- a/app/models/bulkrax/oai_adventist_qdc_entry.rb
+++ b/app/models/bulkrax/oai_adventist_qdc_entry.rb
@@ -2,26 +2,10 @@
 
 module Bulkrax
   class OaiAdventistQdcEntry < OaiQualifiedDcEntry
-    # override to swap out the thumbnail_url
-    def build_metadata
-      self.parsed_metadata = {}
-      self.parsed_metadata[work_identifier] = [record.header.identifier]
-      self.raw_metadata = { record_level_xml: record._source.to_s }
-
-      record.metadata.children.each do |child|
-        child.children.each do |node|
-          add_metadata(node.name, node.content)
-        end
-      end
-
-      add_visibility
-      add_rights_statement
-      add_admin_set_id
-      add_collections
-      # see app/models/concerns/bulkrax/has_local_processing.rb
-      add_local
-
-      self.parsed_metadata
+    # Note: We're overriding the setting of the thumbnail_url as per prior implementations in
+    # Adventist's code-base.
+    def add_thumbnail_url
+      true
     end
   end
 end


### PR DESCRIPTION
Prior to this commit we had an override that "swapped out" the thumbnail.

What did that look like? [Bulkrax::OaiEntry#build_metadata at b857a25b][1] it looked as follows:

```ruby
def build_metadata
  self.parsed_metadata = {}
  self.parsed_metadata[work_identifier] = [record.header.identifier]
  self.raw_metadata = { xml: record.metadata.to_s }

  record.metadata.children.each do |child|
    child.children.each do |node|
      add_metadata(node.name, node.content)
    end
  end
  add_metadata('thumbnail_url', thumbnail_url)

  add_visibility
  add_rights_statement
  add_admin_set_id
  add_collections
  add_local

  return self.parsed_metadata
end
```

Note the main difference is that we removed the
`add_metadata('thumbnail_url', thumbnail_url)`.

After this commit we're leveraging `Bulkrax::OaiQualifiedDcEntry`'s implementation (as defined in [35970cee of Bulkrax][2]) in which we replaced the inline `add_metadata('thumbnail_url', thumbnail_url)` with the method a method (e.g. `add_thumbnail_url`).  Now instead of copying over the entire `#build_metadata` implementation we can simply override a single method.

All of this means we can leverage changes introduced in [PR 703][703] of Bulkrax (e.g. "Ensuring OAI parser sets factory class then parses").

This relates to:

- https://github.com/samvera-labs/bulkrax/issues/702

And should close:

- https://github.com/scientist-softserv/adventist-dl/issues/188
- https://github.com/scientist-softserv/adventist-dl/issues/187

[1]: https://github.com/samvera-labs/bulkrax/blob/b857a25becefc4bd960f25647033dfb2e899386e/app/models/bulkrax/oai_entry.rb#L28-L47

[2]: https://github.com/samvera-labs/bulkrax/tree/35970cee7b1e48d00c3fc838d2ca5790c09e2c9c

[703]:  https://github.com/samvera-labs/bulkrax/pull/703
