### PR TITLE
[i101] Ensuring OAI `title` is not mapped to `part`

### DIFF
--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -55,7 +55,7 @@ if Settings.bulkrax.enabled
         'alt' => { from:  ['geocode'] },
         'publisher' => { from:  ['publisher'] },
         'rights_statement' => { from:  ['rights_statement'] },
-        'part' => { from:  ['part_of', 'title'] },
+        'part' => { from:  ['part_of'] },
         'date_created' => { from:  ['date_created'] },
         'title' => { from:  ['title'] },
         'subject' => { from:  ['subject'] },


### PR DESCRIPTION
Prior to this commit the OaiParser was mapping the `<title>` node of the OAI feed to both the Hyku `title` property and the `part` property. This confusion likely arose between the assumption that we were mapping the MODS entry, which had a node `relatedItem/titleInfo/title`; however we were not mapping a MODs entry.

Instead we were using the custom oai_adl entry.  Of important note, due to the implementation of our OAI parser we look at each grand child node of the `metadata` (e.g. the child node of the `oai_adl` node).  Those nodes include `title` and `part_of`.

With this commit, we no longer map (via OAI parsing) the `title` node into the `part` property of Hyku.

I have confirmed this by [stating the following in Slack][1]:

> I think I have the answer to my question, so I’ll state the answer and
> work from there.
>
> At present, the OAI parser will look at the above XML document and use
> both the title (e.g. “13th Sabbath offering Northern Europe-West
> Africa”) and part_of (e.g. “Lake Union Herald”) as the Hyku “part” /
> “part_of” field (which are aliases for each other in Hyku).
>
> Not knowing the data domain, I didn’t want to assume that “13th Sabbath
> offering Northern Europe-West Africa” wasn’t what this record was part
> of.  (I think in this case that the title element is the article’s
> title).
> (This all only applies to OAI)

Katharine's response is as follows:

> You're right that the "13th Sabbath offering" info is title
> information, not periodical name or collection. It is the article
> title. Metadata that appears as <title> in OAI_ADL should always be
> title info. Your assumptions all look correct to me.

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/101
- https://github.com/scientist-softserv/adventist-dl/issues/186

[1]: https://assaydepot.slack.com/archives/C0313NJV9PE/p1673982875511829?thread_ts=1673879845.088759&cid=C0313NJV9PE

@samvera/hyku-code-reviewers
