### PR TITLE
Adding spring to provide option for faster tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,10 +83,10 @@ group :development do
   gem 'pronto-rails_schema', require: false
   gem 'pronto-rubocop', require: false
 
-  gem 'spring', '~> 1.7'
-  gem 'spring-watcher-listen', '~> 2.0.0'
-
   gem 'scss_lint', require: false
+  gem 'spring', '~> 1.7'
+  gem 'spring-commands-rspec'
+  gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
 # Bulkrax

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1022,6 +1022,8 @@ GEM
       net-http-persistent (~> 4.0, >= 4.0.1)
       rdf (~> 3.1)
     spring (1.7.2)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
@@ -1170,6 +1172,7 @@ DEPENDENCIES
   simplecov
   solr_wrapper (~> 2.0)
   spring (~> 1.7)
+  spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
   tether-rails
   turbolinks (~> 5)

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
+require 'bundler/setup'
+load Gem.bin_path('rspec-core', 'rspec')


### PR DESCRIPTION
To leverage spring, you will need to:

- Start the containers (e.g. `sc up`)
- Run the specs using spring (e.g. `spring rspec path/to/my_spec.rb`)

Spring boots up a Rails server and re-uses that between invocations. This means that instead of spending about 1 minute booting the application to run a 1 second test, you can re-use that app (spending about 8 seconds or so connecting to it) then run that 1 second test.

But beware of spring, as it can create odd behavior in the application. As a matter of practice when you are done testing, run `spring stop` to terminate the spring booted applications.

Related to:

- https://github.com/scientist-softserv/britishlibrary/pull/252
