### PR TITLE
Bumping Fedora memory allocation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,7 @@ services:
     environment:
       - VIRTUAL_PORT=8080
       - VIRTUAL_HOST=fcrepo.hyku.test
-      - JAVA_OPTS=${JAVA_OPTS} -Dfcrepo.modeshape.configuration="classpath:/config/file-simple/repository.json" -Dfcrepo.object.directory="/data/objects" -Dfcrepo.binary.directory="/data/binaries"
+      - JAVA_OPTS=${JAVA_OPTS} -Xmx4g -Dfcrepo.modeshape.configuration="classpath:/config/file-simple/repository.json" -Dfcrepo.object.directory="/data/objects" -Dfcrepo.binary.directory="/data/binaries"
     networks:
       internal:
 

--- a/ops/dev-deploy.tmpl.yaml
+++ b/ops/dev-deploy.tmpl.yaml
@@ -203,6 +203,13 @@ imagePullSecrets:
 
 fcrepo:
   enabled: false
+  resources:
+    limits:
+      memory: "4Gi"
+      cpu: "2"
+    requests:
+      memory: "2Gi"
+      cpu: "1"
 postgresql:
   enabled: false
 redis:

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -203,6 +203,13 @@ imagePullSecrets:
 
 fcrepo:
   enabled: false
+  resources:
+    limits:
+      memory: "4Gi"
+      cpu: "2"
+    requests:
+      memory: "2Gi"
+      cpu: "1"
 postgresql:
   enabled: false
 redis:

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -1,5 +1,6 @@
 replicaCount: 2
 
+# This is for the web-container
 resources:
   requests:
     memory: "1Gi"
@@ -190,6 +191,13 @@ imagePullSecrets:
 
 fcrepo:
   enabled: false
+  resources:
+    limits:
+      memory: "4Gi"
+      cpu: "2"
+    requests:
+      memory: "2Gi"
+      cpu: "1"
 postgresql:
   enabled: false
 redis:


### PR DESCRIPTION
Before this commit, we were seeing `LDP::NotFound` errors which were part of the failure for this [show entry][1].  The resource that we didn't find was the tenant's Fedora ID.  Which we know exists.

Note: This is something we encountered in Loiusville ([see Slack thread][2]).  It has not been resolved in Louisville.

With this commit, we're taking an educated guess as to what will be adequate for fcrepo.  Note, we're keeping production and staging synchronized so that we have comparable environments.

References:

- https://github.com/scientist-softserv/dev-ops/issues/551
- https://github.com/scientist-softserv/adventist-dl/issues/240

[1]: https://adl.s2.adventistdigitallibrary.org/importers/36/entries/186125?locale=en

[2]: https://assaydepot.slack.com/archives/G0313NK5NMA/p1664387275241309
