### PR TITLE
[i240] - override bulkrax #collections_created method

### DIFF
--- a/app/models/bulkrax/oai_adventist_qdc_entry.rb
+++ b/app/models/bulkrax/oai_adventist_qdc_entry.rb
@@ -29,7 +29,7 @@ module Bulkrax
       # We've completed our expensive queries, now let's make sure we don't need to do this again.
       @found_collection_ids = true
 
-      return self.collection_ids
+      self.collection_ids
     end
   end
 end

--- a/app/models/bulkrax/oai_adventist_qdc_entry.rb
+++ b/app/models/bulkrax/oai_adventist_qdc_entry.rb
@@ -7,5 +7,23 @@ module Bulkrax
     def add_thumbnail_url
       true
     end
+
+    def collections_created?
+      true
+    end
+
+    def find_collection_ids
+      return self.collection_ids if collections_created?
+      if sets.blank? || parser.collection_name != 'all'
+        collection = find_collection(importerexporter.unique_collection_identifier(parser.collection_name))
+        self.collection_ids << collection.id if collection.present? && !self.collection_ids.include?(collection.id)
+      else # All - collections should exist for all sets
+        sets.each do |set|
+          c = find_collection(importerexporter.unique_collection_identifier(set.content))
+          self.collection_ids << c.id if c.present? && !self.collection_ids.include?(c.id)
+        end
+      end
+      return self.collection_ids
+    end
   end
 end

--- a/app/models/bulkrax/oai_adventist_qdc_entry.rb
+++ b/app/models/bulkrax/oai_adventist_qdc_entry.rb
@@ -13,7 +13,9 @@ module Bulkrax
     end
 
     def find_collection_ids
-      return self.collection_ids if collections_created?
+      # Using memoization to cache what could be expensive queries.
+      return self.collection_ids if defined?(@found_collection_ids)
+
       if sets.blank? || parser.collection_name != 'all'
         collection = find_collection(importerexporter.unique_collection_identifier(parser.collection_name))
         self.collection_ids << collection.id if collection.present? && !self.collection_ids.include?(collection.id)
@@ -23,7 +25,11 @@ module Bulkrax
           self.collection_ids << c.id if c.present? && !self.collection_ids.include?(c.id)
         end
       end
-      self.collection_ids
+
+      # We've completed our expensive queries, now let's make sure we don't need to do this again.
+      @found_collection_ids = true
+
+      return self.collection_ids
     end
   end
 end

--- a/app/models/bulkrax/oai_adventist_qdc_entry.rb
+++ b/app/models/bulkrax/oai_adventist_qdc_entry.rb
@@ -23,7 +23,7 @@ module Bulkrax
           self.collection_ids << c.id if c.present? && !self.collection_ids.include?(c.id)
         end
       end
-      return self.collection_ids
+      self.collection_ids
     end
   end
 end


### PR DESCRIPTION
# Summary

ref proposed solution and discussion: https://github.com/scientist-softserv/adventist-dl/issues/240#issuecomment-1412456590

Bug: Importers would stay stuck in "pending"

# Screenshots / Video
**BEFORE**  (entries stayed stuck in pending)

<details>

![image](https://user-images.githubusercontent.com/10081604/216427375-6d6f39a5-0eed-4495-a71e-7dc90ddcfb73.png)

</details>



**AFTER** (entries should update their status, even if they fail to import)
<details>

<img width="722" alt="image" src="https://user-images.githubusercontent.com/10081604/216427153-1c1d53a3-ceda-4b8c-b55d-dedc55d79179.png">

![image](https://user-images.githubusercontent.com/10081604/216426795-e23d5d9f-12d6-4568-87bc-99e4c8c0d9fd.png)

</details>

# Expected Behavior
- [ ] Running the following importer should no longer result in pending statuses: https://adl.s2.adventistdigitallibrary.org/importers/35?locale=en NOTE: This passes even if there are failures

