### PR TITLE
Adding spec to verify load order of services

### DIFF
--- a/spec/services/adventist/text_file_text_extraction_service_spec.rb
+++ b/spec/services/adventist/text_file_text_extraction_service_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe Adventist::TextFileTextExtractionService do
     end
   end
 
+  describe 'position in the array of Hyrax::DerivativeService.services' do
+    it "is in the first position" do
+      expect(Hyrax::DerivativeService.services).to match_array(
+        [Adventist::TextFileTextExtractionService, Hyrax::FileSetDerivativesService]
+      )
+    end
+  end
+
   it_behaves_like "a Hyrax::DerivativeService"
 
   describe '#valid?' do


### PR DESCRIPTION
Prior to this commit, I had manually checked but not programmatically verified the order of the services.

We need to verify this because the first service that says it's valid is the one the runs (and the others do not run).

Why have the `Adventist::TextFileTextExtractionService` one first? Because that is the faster one to validate.

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/117
