### PR TITLE
add partOf property mapping for JournalArticle

### DIFF
--- a/app/models/journal_article.rb
+++ b/app/models/journal_article.rb
@@ -8,6 +8,7 @@ class JournalArticle < DogBiscuits::JournalArticle
   include DogBiscuits::BibliographicCitation
   include DogBiscuits::DateIssued
   include DogBiscuits::Geo
+  include DogBiscuits::Part
   include DogBiscuits::PlaceOfPublication
   include DogBiscuits::RemoteUrl
 

--- a/app/models/journal_article.rb
+++ b/app/models/journal_article.rb
@@ -8,7 +8,6 @@ class JournalArticle < DogBiscuits::JournalArticle
   include DogBiscuits::BibliographicCitation
   include DogBiscuits::DateIssued
   include DogBiscuits::Geo
-  include DogBiscuits::Part
   include DogBiscuits::PlaceOfPublication
   include DogBiscuits::RemoteUrl
 

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -55,6 +55,7 @@ if Settings.bulkrax.enabled
         'alt' => { from:  ['geocode'] },
         'publisher' => { from:  ['publisher'] },
         'rights_statement' => { from:  ['rights_statement'] },
+        'part_of' => { from:  ['part_of'] },
         'part' => { from:  ['part_of'] },
         'date_created' => { from:  ['date_created'] },
         'title' => { from:  ['title'] },


### PR DESCRIPTION
# Summary

~~include DogBiscuits::Part module for the JournalArticle model, so that part is an available property for bulkrax mapping.~~

~~This issue did not pass QA because the part property was not being persisted on the JournalArticle model.~~

ref QA: [feedback](https://github.com/scientist-softserv/adventist-dl/issues/101#issuecomment-1416185744)

After re-reading the ticket, I'm not totally sure what the solution is because I'm confused about the problem. But here is what I think: 

1) The ticket's original title referenced PublishedWork. There is a spec about PublishedWork that passes. Additionally, PublishedWork has a "part" property. 
2) However, the ticket references instructions to import and test a JournalArticle, which does not have a part property, but it does have a part_of property. I believe this is intentional. So for now, I added a part_of to part_of mapping to cover the case of the JournalArticle. After doing so, following the ticket's test instructions passes QA. This PR originally added part to the JournalArticle model, which I now think is the wrong approach.


# Screenshots / Video
![Screenshot 2023-02-03 at 11-07-59 Show Entry __ Hyku](https://user-images.githubusercontent.com/10081604/216692625-4912f7fa-5bd7-4d62-a6c4-20e6e7769010.png)
![Screenshot 2023-02-03 at 11-09-20 $0 13 postage stamp convert](https://user-images.githubusercontent.com/10081604/216692644-6bdd5656-7fbb-46eb-82a1-42f0d3882fae.png)




# Expected Behavior

- [x]  Create and run the importer using the below configuration
Importer Configuration

    Base URL: http://oai.adventistdigitallibrary.org/OAI-script
    Metadata Prefix: oai_adl
    Set: sdapi:article
    Limit: 1

Check the first entry's parsed metadata.
  - [x] The title should be ["$0.13 postage stamp convert"]  
  - [x]  the part should be ["Southwestern Union Record"].

Check the corresponding work for that entry.
  - [x] The "Title" should be "$0.13 postage stamp convert"
  - [x]  there should be a "Part" that is "Southwestern Union Record". (label is Periodical)

