### PR TITLE
Add yarn install towards the end of build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,7 @@ COPY --chown=1001:101 $APP_PATH /app/samvera/hyrax-webapp
 
 ARG SETTINGS__BULKRAX__ENABLED="true"
 RUN mkdir -p /app/samvera/branding && ln -s /app/samvera/branding /app/samvera/hyrax-webapp/public/branding && \
-  yarn install && \
-  RAILS_ENV=production SECRET_KEY_BASE=`bin/rake secret` DB_ADAPTER=nulldb DATABASE_URL='postgresql://fake' bundle exec rake assets:precompile
+  RAILS_ENV=production SECRET_KEY_BASE=`bin/rake secret` DB_ADAPTER=nulldb DATABASE_URL='postgresql://fake' bundle exec rake assets:precompile && yarn install
 
 FROM hyku-base as hyku-worker
 ENV MALLOC_ARENA_MAX=2


### PR DESCRIPTION
ref issue: #252 

Using Hyku as a model, we are adding `yarn install` at the end of the build sequence, after assets precompile to see if it build currently on deploys.  This still doesn't seem to solve it for local dev environments though.

ref: a2a0f68d28d55280eac012c53f0fc3c3bec1796d