### PR TITLE
Skipping `identifier` element in OAI metadata XML element

### DIFF
--- a/app/models/bulkrax/oai_adventist_qdc_entry.rb
+++ b/app/models/bulkrax/oai_adventist_qdc_entry.rb
@@ -5,6 +5,16 @@ module Bulkrax
     # @note Adding this to make testing easier.  This is something to push up into Bulkrax default.
     attr_writer :raw_record
 
+    # OVERRIDE Bulkrax::Entry#field_to to skip over the user provided "identifier" field in the
+    # record's metadata.  That field contains a previous catalog's identifier.  Per conversations
+    # with the client, we can skip this field.
+    #
+    # @see https://assaydepot.slack.com/archives/C0313NJV9PE/p1676478120061659?thread_ts=1676476112.956259&cid=C0313NJV9PE
+    def field_to(field)
+      return [] if field == "identifier"
+      super(field)
+    end
+
     # Note: We're overriding the setting of the thumbnail_url as per prior implementations in
     # Adventist's code-base.
     def add_thumbnail_url

--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -53,7 +53,12 @@ module Bulkrax
     end
 
     def find_or_create_collection(collection_title)
-      Collection.where(title_sim: collection_title).first || Collection.create(title: [collection_title], collection_type: Hyrax::CollectionType.find_by(title: 'User Collection'))
+      Collection.where(title_sim: collection_title).first ||
+        Collection.create(title: [collection_title], collection_type: Bulkrax::HasLocalProcessing.default_collection_type)
+    end
+
+    def self.default_collection_type
+      Hyrax::CollectionType.find_or_create_by(title: 'User Collection')
     end
   end
 end

--- a/spec/models/bulkrax/oai_adventist_qdc_entry_spec.rb
+++ b/spec/models/bulkrax/oai_adventist_qdc_entry_spec.rb
@@ -3,6 +3,7 @@
 require "spec_helper"
 require "bulkrax/entry_spec_helper"
 
+# rubocop:disable Metrics/LineLength
 RSpec.describe Bulkrax::OaiAdventistQdcEntry do
   describe "#build_metadata" do
     subject(:entry) do
@@ -17,64 +18,96 @@ RSpec.describe Bulkrax::OaiAdventistQdcEntry do
       )
     end
 
-    let(:identifier) { "20121637" }
-    # rubocop:disable Metrics/LineLength
+    let(:identifier) { "31290115" }
+    let(:work_type) { PublishedWork }
     let(:data) do
       %(<?xml version="1.0" encoding="UTF-8"?>
         <OAI-PMH xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
-          <responseDate>2023-02-01T20:41:11Z</responseDate>
-          <request verb="GetRecord">http://oai.adventistdigitallibrary.org/OAI-script?identifier=#{identifier}&amp;metadataPrefix=oai_adl&amp;verb=GetRecord</request>
+        <responseDate>2023-02-01T20:41:11Z</responseDate>
+        <request verb="GetRecord">http://oai.adventistdigitallibrary.org/OAI-script?identifier=#{identifier}&amp;metadataPrefix=oai_adl&amp;verb=GetRecord</request>
           <GetRecord>
-            <record>
-              <header>
-                <identifier>#{identifier}</identifier>
-                <datestamp>2022-12-15T05:09:20Z</datestamp>
-                <setSpec>adl:book</setSpec>
-              </header>
-              <metadata>
-                <oai_adl>
-                  <abstract>This tract is part of a series of testimonies written by Ellen White and published by the Seventh-day Adventist Church from 1855 to 1909.</abstract>
-                  <aark_id>20121637</aark_id>
-                  <identifier>b10134815_06; W11 .T5</identifier>
-                  <creator>White, Ellen Gould Harmon, 1827-1915</creator>
-                  <title>Testimony for the Church: Number 7</title>
-                  <resource_type>Book</resource_type>
-                  <date_created>1862-01-01</date_created>
-                  <language>English</language>
-                  <extent>no. in v. ; 15 cm.</extent>
-                  <source>Center for Adventist Research</source>
-                  <geocode>42.323991, -85.190425</geocode>
-                  <place_of_publication>Battle Creek, Michigan, USA</place_of_publication>
-                  <part_of>John N. Andrews Library Collection</part_of>
-                  <publisher>Steam Press of the Seventh-Day Adventist Publishing Association; Other Publisher</publisher>
-                  <rights_statement>No Copyright – United States</rights_statement>
-                  <subject>Charity -- Dress Reform -- Spiritualism; Civil War, 1861-1865 -- Slavery; History; Visions -- Censures; White, Ellen Gould Harmon, 1827-1915</subject>
-                  <work_type>PublishedWork</work_type>
-                 </oai_adl>
-               </metadata>
-            </record>
-          </GetRecord>
-        </OAI-PMH>)
+          <record>
+          <header>
+          <identifier>#{identifier}</identifier>
+            <datestamp>2022-12-15T05:09:20Z</datestamp>
+            <setSpec>adl:book</setSpec>
+            </header>
+            <metadata>
+            <oai_adl>
+            <abstract>This tract is part of a series of testimonies written by Ellen White and published by the Seventh-day Adventist Church from 1855 to 1909.</abstract>
+            <aark_id>#{identifier}</aark_id>
+              <identifier>.b#{identifier}1</identifier>
+                <creator>White, Ellen Gould Harmon, 1827-1915</creator>
+                <title>Testimony for the Church: Number 7</title>
+                <resource_type>Book</resource_type>
+                <date_created>1862-01-01</date_created>
+                <language>English</language>
+                <extent>no. in v. ; 15 cm.</extent>
+                <source>Center for Adventist Research</source>
+                <geocode>42.323991, -85.190425</geocode>
+                <place_of_publication>Battle Creek, Michigan, USA</place_of_publication>
+                <part_of>John N. Andrews Library Collection</part_of>
+                <publisher>Steam Press of the Seventh-Day Adventist Publishing Association; Other Publisher</publisher>
+                <rights_statement>No Copyright – United States</rights_statement>
+                <subject>Charity -- Dress Reform -- Spiritualism; Civil War, 1861-1865 -- Slavery; History; Visions -- Censures; White, Ellen Gould Harmon, 1827-1915</subject>
+                <pagination>[16]</pagination>
+                <volume_number>178</volume_number>
+                <location>Somewhere over the rainbow</location>
+                <work_type>#{work_type}</work_type>
+                  </oai_adl>
+                  </metadata>
+                  </record>
+                  </GetRecord>
+                  </OAI-PMH>)
     end
 
-    # rubocop:enable Metrics/LineLength
-    it "assigns the factory class" do
-      entry.build_metadata
+    # rubocop:disable RSpec/ExampleLength
+    context 'for a Published Work' do
+      let(:work_type) { PublishedWork }
 
-      expect(entry.factory_class).to eq(PublishedWork)
-      expect(entry.parsed_metadata.fetch('title')).to eq(["Testimony for the Church: Number 7"])
-      expect(entry.parsed_metadata.fetch('part')).to eq(["John N. Andrews Library Collection"])
-      expect(entry.parsed_metadata.fetch('publisher')).to eq(
-        ["Steam Press of the Seventh-Day Adventist Publishing Association", "Other Publisher"]
-      )
-      expect(entry.parsed_metadata.fetch('subject')).to eq(
-        [
-          "Charity -- Dress Reform -- Spiritualism",
-          "Civil War, 1861-1865 -- Slavery",
-          "History", "Visions -- Censures",
-          "White, Ellen Gould Harmon, 1827-1915"
-        ]
-      )
+      it "parses the metadata" do
+        entry.build_metadata
+
+        expect(entry.factory_class).to eq(work_type)
+        expect(entry.parsed_metadata.fetch('title')).to eq(["Testimony for the Church: Number 7"])
+        expect(entry.parsed_metadata.fetch('part')).to eq(["John N. Andrews Library Collection"])
+        expect(entry.parsed_metadata.fetch('pagination')).to eq(["[16]"])
+        expect(entry.parsed_metadata.fetch('volume_number')).to eq(["178"])
+        expect(entry.parsed_metadata.fetch('location')).to eq(["Somewhere over the rainbow"])
+        expect(entry.parsed_metadata.fetch('identifier')).to eq([identifier])
+
+        expect(entry.parsed_metadata.fetch('publisher')).to eq(
+          ["Steam Press of the Seventh-Day Adventist Publishing Association", "Other Publisher"]
+        )
+        expect(entry.parsed_metadata.fetch('subject')).to eq(
+          [
+            "Charity -- Dress Reform -- Spiritualism",
+            "Civil War, 1861-1865 -- Slavery",
+            "History", "Visions -- Censures",
+            "White, Ellen Gould Harmon, 1827-1915"
+          ]
+        )
+      end
+    end
+    # rubocop:enable RSpec/ExampleLength
+
+    context 'for a Journal Article' do
+      let(:work_type) { JournalArticle }
+
+      before { Bulkrax::HasLocalProcessing.default_collection_type }
+
+      it "parses the metadata" do
+        entry.build_metadata
+
+        expect(entry.factory_class).to eq(work_type)
+        expect(entry.parsed_metadata.fetch('title')).to eq(["Testimony for the Church: Number 7"])
+        expect(entry.parsed_metadata.fetch('part_of')).to eq(["John N. Andrews Library Collection"])
+        expect(entry.parsed_metadata.fetch('pagination')).to eq(["[16]"])
+        expect(entry.parsed_metadata.fetch('volume_number')).to eq(["178"])
+        expect(entry.parsed_metadata.fetch('location')).to eq(["Somewhere over the rainbow"])
+        expect(entry.parsed_metadata.fetch('identifier')).to eq([identifier])
+      end
     end
   end
 end
+# rubocop:enable Metrics/LineLength


### PR DESCRIPTION
Prior to this commit we had two "identifier" elements.  In our baseline `Bulkrax::OaiEntry` implementation, we assign the `header > identifier` to the `identifier` property (as defined by the bulkrax configuration for the `source_identifier: true` property.  We also assigned the `metadata > identifier` element to the `identifier` property based on the `from: ['identifier']` mapping.

The end result was that our `identifier` property got the following values: `["13129009", ".b31290097"]`.  Which might cause problems given the expectations around the [`source_identifier` in Bulkrax][1].

With this commit, we short-circuit the `field_to` logic to return an empty array.  Thus ignoring the `metadata > identifier` value.  The `field_to` logic is not called for the `header > identifier` but only for the `metadata` elements.

[1]: https://github.com/samvera-labs/bulkrax/wiki/CSV-Importer#source-identifier

Below is the XML example to help clarify the above prior and current state.

```xml
<OAI-PMH xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.openarchives.org/OAI/2.0/" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
  <responseDate>2023-02-15T16:23:07Z</responseDate>
  <request verb="GetRecord">
https://oai.adventistdigitallibrary.org/OAI-script?verb=GetRecord&metadataPrefix=oai_adl&identifier=13129009
  </request>
  <GetRecord>
    <record>
    <header>
    <identifier>13129009</identifier>
    </header>
    <metadata>
    <oai_adl>
    <aark_id>13129009</aark_id>
    <identifier>.b31290097</identifier>
    </oai_adl>
    </metdata>
    </record>
  </GetRecord>
</OAI-PMH>
```

