### PR TITLE
Ensuring that collections can add to collections

### DIFF
--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -46,8 +46,8 @@ module Bulkrax
       if self.parsed_metadata['part_of'].present?
         self.parsed_metadata['part_of'].each do |collection_title|
           collection = find_or_create_collection(collection_title)
-          self.parsed_metadata['collection'] ||= []
-          self.parsed_metadata['collection'] << collection.id
+          self.parsed_metadata[parser.related_parents_parsed_mapping] ||= []
+          self.parsed_metadata[parser.related_parents_parsed_mapping] << collection.id
         end
       end
     end

--- a/spec/bulkrax/entry_spec_helper.rb
+++ b/spec/bulkrax/entry_spec_helper.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require 'oai'
+require 'xml/libxml'
+
+module Bulkrax
+  ##
+  # The purpose of this module is to provide some testing facilities for those that include the
+  # Bulkrax gem in their application.
+  #
+  # This module came about through a desire to expose a quick means of vetting the accuracy of the
+  # different parsers.
+  module EntrySpecHelper
+    ##
+    # @api public
+    # @since v5.0.1
+    #
+    # The purpose of this method is encapsulate the logic of creating the appropriate Bulkrax::Entry
+    # object based on the given data, identifier, and parser_class_name.
+    #
+    # From that entry, you should be able to test how {Bulkrax::Entry#build_metadata} populates the
+    # {Bulkrax::Entry#parsed_metadata} variable.  Other uses may emerge.
+    #
+    # @param data [Object] the data that we use to populate the raw metadata.  Due to implementation
+    #        details of each entry, the data will be of different formats.
+    #
+    # @param identifier [String, Integer] The identifier of the entry.  This might also be found in
+    #        the metadata of the entry, but for instantiation purposes we need this value.
+    # @param parser_class_name [String] The name of the parser class you're wanting to test.
+    # @param options [Hash<Symbol,Object>] these are to be passed along into the instantiation of
+    #        the various classes.  See implementation details.
+    #
+    # @return [Bulkrax::Entry]
+    def self.entry_for(data:, identifier:, parser_class_name:, **options)
+      importer = importer_for(parser_class_name: parser_class_name, **options)
+
+      # Using an instance of the entry_class to dispatch to different
+      entry_for_dispatch = options.fetch(:entry_class) { importer.parser.entry_class }.new
+
+      # Using the {is_a?} test we get the benefit of inspecting an object's inheritance path
+      # (e.g. ancestry).  The logic, as implemented, also provides a mechanism for folks in their
+      # applications to add a {class_name_entry_for}; something that I suspect isn't likely
+      # but given the wide variety of underlying needs I could see happening and I want to encourage
+      # patterned thinking to fold that different build method into this structure.
+      key = entry_class_to_symbol_map.keys.detect { |class_name| entry_for_dispatch.is_a?(class_name.constantize) }
+
+      # Yes, we'll raise an error if we didn't find a corresponding key.  And that's okay.
+      symbol = entry_class_to_symbol_map.fetch(key)
+
+      send("build_#{symbol}_entry_for", importer: importer, identifier: identifier, data: data, **options)
+    end
+
+    DEFAULT_ENTRY_CLASS_TO_SYMBOL_MAP = {
+      'Bulkrax::OaiEntry' => :oai,
+      'Bulkrax::XmlEntry' => :xml,
+      'Bulkrax::CsvEntry' => :csv
+    }.freeze
+
+    # Present implementations of entry classes tend to inherit from the below listed class names.
+    # We're not looking to register all descendents of the {Bulkrax::Entry} class, but instead find
+    # the ancestor where there is significant deviation.
+    def self.entry_class_to_symbol_map
+      @entry_class_to_symbol_map || DEFAULT_ENTRY_CLASS_TO_SYMBOL_MAP
+    end
+
+    def self.entry_class_to_symbol_map=(value)
+      @entry_class_to_symbol_map = value
+    end
+
+    def self.importer_for(parser_class_name:, parser_fields: {}, **options)
+      # Ideally, we could pass in the field_mapping.  However, there is logic that ignores the
+      # parser's field_mapping and directly asks for Bulkrax's field_mapping (e.g. model_mapping
+      # method).
+      if options.key?(:importer_field_mapping)
+        Rails.logger.warn("You passed :importer_field_mapping as an option.  This may not fully work as desired.")
+      end
+      Bulkrax::Importer.new(
+        name: options.fetch(:importer_name, "Test importer for identifier"),
+        admin_set_id: options.fetch(:importer_admin_set_id, "admin_set/default"),
+        user: options.fetch(:importer_user, User.new(email: "hello@world.com")),
+        limit: options.fetch(:importer_limits, 1),
+        parser_klass: parser_class_name,
+        field_mapping: options.fetch(:importer_field_mappings) { Bulkrax.field_mappings.fetch(parser_class_name) },
+        parser_fields: parser_fields
+      )
+    end
+    private_class_method :importer_for
+
+    ##
+    # @api private
+    #
+    # @param data [Hash<Symbol,String>] we're expecting a hash with keys that are symbols and then
+    #        values that are strings.
+    #
+    # @return [Bulkrax::CsvEntry]
+    #
+    # @note As a foible of this implementation, you'll need to include along a CSV to establish the
+    #       columns that you'll parse (e.g. the first row
+    def self.build_csv_entry_for(importer:, data:, identifier:, **_options)
+      options.fetch(:entry_class) { importer.parser.entry_class }.new(
+        importerexporter: importer,
+        identifier: identifier,
+        raw_metadata: data
+      )
+    end
+
+    ##
+    # @api private
+    #
+    # @param data [String] we're expecting a string that is well-formed XML for OAI parsing.
+    #
+    # @return [Bulkrax::OaiEntry]
+    def self.build_oai_entry_for(importer:, data:, identifier:, **options)
+      # The raw record assumes we take the XML data, parse it and then send that to the
+      # OAI::GetRecordResponse object.
+      doc = XML::Parser.string(data)
+      raw_record = OAI::GetRecordResponse.new(doc.parse)
+
+      raw_metadata = {
+        importer.parser.source_identifier.to_s => identifier,
+        "data" => data,
+        "collections" => options.fetch(:raw_metadata_collections, []),
+        "children" => options.fetch(:raw_metadata_children, [])
+      }
+
+      options.fetch(:entry_class) { importer.parser.entry_class }.new(
+        raw_record: raw_record,
+        importerexporter: importer,
+        identifier: identifier,
+        raw_metadata: raw_metadata
+      )
+    end
+
+    ##
+    # @api private
+    #
+    # @param data [String] we're expecting a string that is well-formed XML.
+    #
+    # @return [Bulkrax::XmlEntry]
+    def self.build_xml_entry_for(importer:, data:, identifier:, **options)
+      raw_metadata = {
+        importer.parser.source_identifier.to_s => identifier,
+        "data" => data,
+        "collections" => options.fetch(:raw_metadata_collections, []),
+        "children" => options.fetch(:raw_metadata_children, [])
+      }
+
+      options.fetch(:entry_class) { importer.parser.entry_class }.new(
+        importerexporter: importer,
+        identifier: identifier,
+        raw_metadata: raw_metadata
+      )
+    end
+  end
+end

--- a/spec/models/bulkrax/oai_adventist_set_entry_spec.rb
+++ b/spec/models/bulkrax/oai_adventist_set_entry_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "bulkrax/entry_spec_helper"
+
+RSpec.describe Bulkrax::OaiAdventistSetEntry do
+  describe "#build_metadata" do
+    subject(:entry) do
+      Bulkrax::EntrySpecHelper.entry_for(
+        entry_class: described_class,
+        identifier: identifier,
+        data: data,
+        parser_class_name: "Bulkrax::OaiAdventistQdcParser"
+      )
+    end
+
+    let(:identifier) { "20000026" }
+    let(:collection_title) { "Rumah Tangga Dan Kesehatan" }
+    # rubocop:disable Metrics/LineLength
+    let(:data) do
+      %(<?xml version="1.0" encoding="UTF-8"?>
+        <OAI-PMH xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+          <responseDate>2023-02-01T20:41:11Z</responseDate>
+          <request verb="GetRecord">http://oai.adventistdigitallibrary.org/OAI-script?identifier=#{identifier}&amp;metadataPrefix=oai_adl&amp;verb=GetRecord</request>
+          <GetRecord>
+            <record>
+            <header>
+              <identifier>#{identifier}</identifier> <datestamp>2022-12-15T05:09:20Z</datestamp> <setSpec>adl:periodical</setSpec>
+            </header>
+            <metadata><oai_adl>
+              <aark_id>#{identifier}</aark_id><title>Pertandaan Zaman</title><resource_type>Periodical</resource_type><date_created>1901-01-01</date_created><language>Malay</language><extent>v. illus. 4to and fol.</extent><source>Center for Adventist Research</source><place_of_publication>Singapore</place_of_publication><publisher>The Signs Press</publisher><rights_statement>No Copyright - United States</rights_statement><part_of>#{collection_title}</part_of><work_type>Collection</work_type>
+            </oai_adl></metadata>
+            </record>
+          </GetRecord>
+        </OAI-PMH>)
+    end
+
+    # rubocop:enable Metrics/LineLength
+    it "sets a pending relationship for the part_of collection" do
+      # This needs to be persisted for saving the entry
+      entry.importer.save!
+      entry.importer.importer_runs.create!
+      entry.save!
+
+      expect { entry.build }.to change(Bulkrax::PendingRelationship, :count).by(1)
+
+      relationship = Bulkrax::PendingRelationship.last
+      relationship.child_id = identifier
+      expect(Collection.find(relationship.parent_id).title).to eq([collection_title])
+    end
+  end
+end


### PR DESCRIPTION
Prior to this commit, we were taking the `part_of` property (and any member of collection attributes) and moving them into the `collection` property.  The `collection` property was then ignored in later parsing.

The intention was to put the collection identifiers into the parsed_metadata field that would represent the member of collection property.  Which, by default in Bulkrax is `parents`.

With this commit, we are mapping the collections into the `parents` parsed metadata, which in turn will schedule the
`Bulkrax::CreateRelationshipsJob` and thus establish the relationship.

In reviewing #203, we are unclear, but have conjecture, about why there are additional relationships.  This addresses adding the missing `part_of` relationship that we were expecting to be present.

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/203