### PR TITLE
i228 - Fix CSV metadata

### DIFF
--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -19,7 +19,7 @@
 <%= presenter.attribute_to_html(:place_of_publication) %>
 <%= presenter.attribute_to_html(:bibliographic_citation) %>
 <%= presenter.attribute_to_html(:remote_url, render_as: :external_link) %>
-<%= presenter.attribute_to_html(:rights_statement) %>
+<%= presenter.attribute_to_html(:rights_statement, render_as: :rights_statement, html_dl: true) %>
 <%= presenter.attribute_to_html(:extent) %>
 <%= presenter.attribute_to_html(:date_issued, label: 'Date') %>
 <%= presenter.attribute_to_html(:alt, label: 'Publication GeoCode') %>

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -87,7 +87,7 @@ if Settings.bulkrax.enabled
         'alt' => { from:  ['coverage.spatial'] },
         'publisher' => { from:  ['publisher'], split: ';' },
         'rights_statement' => { from:  ['rights'] },
-        'part' => { from:  ['relation.isPartOf'] },
+        'part_of' => { from:  ['relation.isPartOf'] },
         'date_created' => { from:  ['date.other'] },
         'title' => { from:  ['title'] },
         'subject' => { from:  ['subject'], split: ';' },

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -88,6 +88,7 @@ if Settings.bulkrax.enabled
         'publisher' => { from:  ['publisher'], split: ';' },
         'rights_statement' => { from:  ['rights'] },
         'part_of' => { from:  ['relation.isPartOf'] },
+        'part' => { from:  ['relation.isPartOf'] },
         'date_created' => { from:  ['date.other'] },
         'title' => { from:  ['title'] },
         'subject' => { from:  ['subject'], split: ';' },

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -83,6 +83,7 @@ RSpec.describe Bulkrax::CsvEntry do
       expect(entry.factory_class).to eq(GenericWork)
       expect(entry.parsed_metadata.fetch('subject')).to eq ["Andrews, John Nevins 1891-1980", "Smith, John"]
       expect(entry.parsed_metadata.fetch('publisher')).to eq ["First Publisher", "Second Publisher"]
+      expect(entry.parsed_metadata.fetch('part_of')).to eq ["Center for Adventist Research Photograph Collection"]
     end
   end
 end


### PR DESCRIPTION
ref: #228 

I believe this addresses all of [Katharine's concerns](https://github.com/scientist-softserv/adventist-dl/issues/228#issuecomment-1423015396).

- [x] needs the AARK Identifier
- [x] map relation.isPartOf to partOf, although there was metadata in a field with that title.
- [x] map format.extent to extent (test on something that is not `GenericWork`)
- [x] render Rights Statement as human readable field

---
In `bulkrax.rb` had `part` instead of `part_of` so the fields were not
mapping correctly, a test was added to the CsvEntrySpec.  Curious, since
in the OAI parser there is a `part` field as well as a `part_of` field.
When checking on the model, I didn't see a `part` property and only a
`part_of` property.

The `rights_statement` was not being rendered properly on the view
template and that has been corrected.

---
**Resulting metadata:**
![image](https://user-images.githubusercontent.com/19597776/219230799-b09ef882-944b-4a1e-b386-86cd269b6064.png)