### PR TITLE
Adding SHA to deploy action

### DIFF
--- a/.github/workflows/deploy-adventist-cluster.yaml
+++ b/.github/workflows/deploy-adventist-cluster.yaml
@@ -1,5 +1,5 @@
 name: "Deploy adventist cluster"
-run-name: Deploy (${{ github.ref_name }} -> ${{ inputs.environment }}) by @${{ github.actor }}
+run-name: Deploy ${{ inputs.environment }} ${{ github.ref_name }}@${{ github.sha }} by @${{ github.actor }}
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/deploy-softserv-staging-cluster.yaml
+++ b/.github/workflows/deploy-softserv-staging-cluster.yaml
@@ -1,5 +1,5 @@
 name: "Deploy softserv staging cluster"
-run-name: Deploy (${{ github.ref_name }} -> ${{ inputs.environment }}) by @${{ github.actor }}
+run-name: Deploy ${{ inputs.environment }} ${{ github.ref_name }}@${{ github.sha }} by @${{ github.actor }}
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
With this commit, we can see the SHA that was deployed to the cluster.

Knowing the branch name is useful, but when debugging and trying to understand state, seeing the SHA is very helpful

