### PR TITLE
Ensuring metadataPrefix is passed with each request

### DIFF
--- a/lib/oai/client_decorator.rb
+++ b/lib/oai/client_decorator.rb
@@ -1,0 +1,32 @@
+module OAI
+  # The purpose of this module is to work around the OAI implementation of Adventist; namely
+  # the fact that after we pass make a resumption request, we loose our metadata_prefix context.
+  #
+  # Typically, the resumption token represents the full context of the previous request.  However,
+  # in the Adventist implementation it's operating a bit like a pagination page indicator.
+  #
+  # @see https://github.com/scientist-softserv/adventist-dl/issues/271
+  module ClientDecorator
+    # @note override
+    def do_resumable(responseClass, verb, opts)
+      # NOTE: We need to close the options because throughout the life-cycle, the opts is deleted
+      #       and updated.  This allows us to preserve
+      original_options = opts.clone
+      responseClass.new(do_request(verb, opts)) do |response|
+        responseClass.new(
+          do_request(verb, original_options.merge(:resumption_token => response.resumption_token))
+        )
+      end
+    end
+
+    # @note override
+    def is_resumption?(opts)
+      # The original method tested that the only key in the options was the resumption_token.  Which
+      # if it wasn't would then raise an exception.
+      return true if opts.keys.include?(:resumption_token)
+      false
+    end
+  end
+end
+
+OAI::Client.prepend(OAI::ClientDecorator)

--- a/lib/oai/client_decorator.rb
+++ b/lib/oai/client_decorator.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+# rubocop:disable Naming/VariableName
+# rubocop:disable Naming/PredicateName
 module OAI
   # The purpose of this module is to work around the OAI implementation of Adventist; namely
   # the fact that after we pass make a resumption request, we loose our metadata_prefix context.
@@ -16,7 +20,7 @@ module OAI
         # This block is the &resumption_token that we pass to the below
         # `OAI::ResponseDecorator#initialize` method call.
         responseClass.new(
-          do_request(verb, original_options.merge(:resumption_token => response.resumption_token))
+          do_request(verb, original_options.merge(resumption_token: response.resumption_token))
         )
       end
     end
@@ -70,6 +74,8 @@ module OAI
     end
   end
 end
+# rubocop:enable Naming/VariableName
+# rubocop:enable Naming/PredicateName
 
 OAI::Client.prepend(OAI::ClientDecorator)
 OAI::Response.prepend(OAI::ResponseDecorator)


### PR DESCRIPTION
## Ensuring metadataPrefix is passed with each request

5963a3d635ec825290941014f84d19e8233cf9c3

Prior to this commit, when we made our request to the first page of the
OAI feed, we would get the expected metadata format.  But after that,
when we'd make a request with the resumption token, we'd lose the
metadata prefix and fallback to a non-desirous metadata format (which
created many metadata errors).

With this commit, we continue to send not just the resumption token, but
also all of the previous URL context.  The OAI spec says we shouldn't
because we can infer it from the resumption token but Adventist
implementation ignores, as it treats the resumption_token as a
pagination page marker.

<details>
<summary>Test Ruby Code for OAI pagination</summary>

```ruby
gem "oai"
require 'oai'
require 'debug'
require File.expand_path('lib/oai/client_decorator', __dir__)

client = OAI::Client.new(
  "http://oai.adventistdigitallibrary.org/OAI-script",
  headers: { from: "jeremy@scientist.com" },
  parser: 'libxml')

opts = {
  metadata_prefix: "oai_adl"
}

sets = ["adl:periodical"]
sets.each do |set|
  records = client.list_records(opts.merge(set: set))

  records.full.each_with_index do |r, i|
    next if i < 24
    break if i > 25
    puts "Index: #{i}"
    puts r._source
  end
end

```

</details>

<details>
<summary>Last record of the first page of OAI feed</summary>

```xml
<record>
      <header>
        <identifier>20000061</identifier>
        <datestamp>2022-12-15T05:09:20Z</datestamp>
        <setSpec>adl:periodical</setSpec>
      </header>
      <metadata><oai_adl><abstract>School paper for Washington University.</abstract><aark_id>20000061</aark_id><identifier>CAR Periodical</identifier><title>Columbia Journal: 1981-; The Sligonian: 1916-1980</title><resource_type>Periodical</resource_type><date_created>1916-01-01</date_created><language>English</language><description>Spring Annual issue served as the college yearbook, 1916-1925.</description><extent>65 v. : ill. ; 23-56 cm.</extent><source>Center for Adventist Research</source><place_of_publication>Takoma Park, Maryland, USA</place_of_publication><publisher>Student's Association of Washington Missionary College</publisher><rights_statement>No Copyright - United States</rights_statement><subject>Columbia Union College; Education; Washington Missionary College (Takoma Park, Md.); Washington University</subject><related_url>https://adl-ebstore-repo.s3.amazonaws.com/20/0000/20000061/20000061.OBJ.jpg</related_url><thumbnail_url>https://adl-ebstore-repo.s3.amazonaws.com/20/0000/20000061/20000061.TN.jpg</thumbnail_url><work_type>Collection</work_type></oai_adl></metadata>
    </record>
```

</details>

<details>
<summary>The first record of the second page</summary>

```xml
<record>
      <header>
        <identifier>20000062</identifier>
        <datestamp>2022-12-15T05:09:20Z</datestamp>
        <setSpec>adl:periodical</setSpec>
      </header>
      <metadata><oai_adl><abstract>Official publication of the Atlantic Union Conference of Seventh-day Adventists</abstract><aark_id>20000062</aark_id><identifier>BX6137.A8 A1</identifier><title>Atlantic Union Gleaner</title><resource_type>Periodical</resource_type><date_created>1902-01-01</date_created><language>English</language><extent>v. : ill. 28 cm.</extent><source>Center for Adventist Research</source><place_of_publication>South Lancaster, MA</place_of_publication><publisher>Atlantic Union Conference of Seventh-day Adventists</publisher><rights_statement>No Copyright - United States</rights_statement><subject>Atlantic Union Conference of Seventh-day Adventists; Seventh-day Adventists</subject><related_url>https://adl-ebstore-repo.s3.amazonaws.com/20/0000/20000062/20000062.OBJ.jpg</related_url><thumbnail_url>https://adl-ebstore-repo.s3.amazonaws.com/20/0000/20000062/20000062.TN.jpg</thumbnail_url><work_type>Collection</work_type></oai_adl></metadata>
    </record>
```

</details>

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/271

## Halting resumption if there are no more records

c7c2e6c9cd98d3d1f8144228a75072ceeb3b4203

Prior to this commit, we would attempt to request infinite items from
the OAI feed because the feed would continue to have a `resumptionToken`
XML node.

With this commit, we're tracking whether or not the `resumptionToken`
has a `completeListSize`; and if it doesn't we abort the process.  This
does mean that we will likely make one extra call.

<details>
<summary>Ruby Code to Verify Behavior</summary>

```ruby
gem "oai"
require 'oai'
require 'debug'
require File.expand_path('lib/oai/client_decorator', __dir__)

client = OAI::Client.new(
  "http://oai.adventistdigitallibrary.org/OAI-script",
  headers: { from: "jeremy@scientist.com" },
  parser: 'libxml')

opts = {
  metadata_prefix: "oai_adl"
}

sets = ["adl:periodical"]
sets.each do |set|
  records = client.list_records(opts.merge(set: set))

  records.full.each_with_index do |r, i|
    if i % 25 == 0
      puts "Index: #{i}"
    end
  end
end
```

</details>

<details>
<summary>Output of the above Ruby Code with the changes</summary>

```shell
Index: 0
Index: 25
Index: 50
Index: 75
Index: 100
Index: 125
Index: 150
```

</details>

<details>
<summary>Output of the above Ruby Code with the code changes to
resumption toekn</summary>

```shell
Index: 0
Index: 25
Index: 50
Index: 75
Index: 100
Index: 125
Index: 150
Index: 175
Index: 200
Index: 225
...
Index: 2025
Index: 2050
...
Index: ∞
```

</details>

Ideally we would instead look at the `completeListSize` attribute and
track a counter, but the implementation details of the gem are such that
this is a somewhat obtuse pathway.

Alternatively, instead of leveraging the `getRecords` verb, we could
first get the identifiers (assuming it has an agreeable
`resumptionToken`) and then get each of those records individually.

However, this solution might help us mitigate/avoid further upstream
issues from upstream OIA provider.

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/271
