### PR TITLE
Removing automatic OAI collection creation

### DIFF
--- a/app/models/bulkrax/oai_adventist_qdc_entry.rb
+++ b/app/models/bulkrax/oai_adventist_qdc_entry.rb
@@ -2,9 +2,6 @@
 
 module Bulkrax
   class OaiAdventistQdcEntry < OaiQualifiedDcEntry
-    # @note Adding this to make testing easier.  This is something to push up into Bulkrax default.
-    attr_writer :raw_record
-
     # OVERRIDE Bulkrax::Entry#field_to to skip over the user provided "identifier" field in the
     # record's metadata.  That field contains a previous catalog's identifier.  Per conversations
     # with the client, we can skip this field.
@@ -21,28 +18,14 @@ module Bulkrax
       true
     end
 
+    # @see https://github.com/scientist-softserv/adventist-dl/issues/281
     def collections_created?
       true
     end
 
+    # @see https://github.com/scientist-softserv/adventist-dl/issues/281
     def find_collection_ids
-      # Using memoization to cache what could be expensive queries.
-      return self.collection_ids if defined?(@found_collection_ids)
-
-      if sets.blank? || parser.collection_name != 'all'
-        collection = find_collection(importerexporter.unique_collection_identifier(parser.collection_name))
-        self.collection_ids << collection.id if collection.present? && !self.collection_ids.include?(collection.id)
-      else # All - collections should exist for all sets
-        sets.each do |set|
-          c = find_collection(importerexporter.unique_collection_identifier(set.content))
-          self.collection_ids << c.id if c.present? && !self.collection_ids.include?(c.id)
-        end
-      end
-
-      # We've completed our expensive queries, now let's make sure we don't need to do this again.
-      @found_collection_ids = true
-
-      self.collection_ids
+      self.collection_ids = []
     end
   end
 end

--- a/app/models/bulkrax/oai_adventist_set_entry.rb
+++ b/app/models/bulkrax/oai_adventist_set_entry.rb
@@ -23,7 +23,6 @@ module Bulkrax
       # added as an override that I'd love to see "removed"
       add_visibility
       add_rights_statement
-      add_admin_set_id
 
       # see app/models/concerns/bulkrax/has_local_processing.rb
       add_local

--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -6,59 +6,7 @@ module Bulkrax
     # add any special processing here, for example to reset a metadata property
     # to add a custom property from outside of the import data
     def add_local
-      if self.parsed_metadata['model'] == 'Collection' || factory_class == Collection
-        add_collection_nesting
-      else
-        add_part_of_collections if self.parsed_metadata['part_of'].present?
-        add_set_collections
-      end
-    end
-
-    def add_set_collections
-      # The #header method is for OAI records
-      return unless record.respond_to?(:header)
-      sets = record.header.set_spec.map(&:content)
-      aark_ids = sets.select { |s| s.match(/^\d+$/) }
-      aark_ids.each do |aark|
-        collection = Collection.where(aark_id_tesim: aark).first
-        add_collection_to_work(collection) if collection
-      end
-    end
-
-    def add_part_of_collections
-      self.parsed_metadata['part_of'].each do |collection_title|
-        collection = find_or_create_collection(collection_title)
-        add_collection_to_work(collection)
-      end
-    end
-
-    def add_collection_to_work(collection)
-      self.parsed_metadata['member_of_collections_attributes'] ||= {}
-      top_key = self.parsed_metadata['member_of_collections_attributes'].keys.map { |k| k.to_i }.sort.last || -1
-      self.parsed_metadata['member_of_collections_attributes'][(top_key + 1).to_s] = { id: collection.id }
-    end
-
-    def add_collection_nesting
-      self.parsed_metadata.delete('admin_set_id')
-      nested_collections = self.parsed_metadata.delete('member_of_collections_attributes')
-      self.parsed_metadata['collection'] = nested_collections.map { |k, v| v[:id] } if nested_collections.is_a?(Hash)
-
-      if self.parsed_metadata['part_of'].present?
-        self.parsed_metadata['part_of'].each do |collection_title|
-          collection = find_or_create_collection(collection_title)
-          self.parsed_metadata[parser.related_parents_parsed_mapping] ||= []
-          self.parsed_metadata[parser.related_parents_parsed_mapping] << collection.id
-        end
-      end
-    end
-
-    def find_or_create_collection(collection_title)
-      Collection.where(title_sim: collection_title).first ||
-        Collection.create(title: [collection_title], collection_type: Bulkrax::HasLocalProcessing.default_collection_type)
-    end
-
-    def self.default_collection_type
-      Hyrax::CollectionType.find_or_create_by(title: 'User Collection')
+      true
     end
   end
 end


### PR DESCRIPTION
Prior to this commit we were attempting to create collections from the OAI feed's metadata.  This has been a source of consistent consternation.

With this commit, we're removing the auto-creation and attempts at assigning collections to imported records.  Instead the client will import OAI records, then export those records via CSV.  They will then update the CSV to create the relationships between records and their membership in collections.  They will then import that updated CSV into Bulkrax.

The current version of Bulkrax includes the [patch][1] that addresses exporter memory issues.

Further, the `Bulrkax::HasLocalProcessing` module masked the setting of admin_set_id creating an error.  The code removed in this commit was previously deleting the `admin_set_id` from the Collection.

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/281

[1]: https://github.com/samvera-labs/bulkrax/pull/749
