### PR TITLE
Configuring all models to have IiifPrint configuration

### DIFF
--- a/app/models/conference_item.rb
+++ b/app/models/conference_item.rb
@@ -19,4 +19,7 @@ class ConferenceItem < DogBiscuits::ConferenceItem
   before_save :combine_dates
 
   prepend OrderAlready.for(:creator)
+  include IiifPrint.model_configuration(
+    pdf_split_child_model: self
+  )
 end

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -19,4 +19,7 @@ class Dataset < DogBiscuits::Dataset
   before_save :combine_dates
 
   prepend OrderAlready.for(:creator)
+  include IiifPrint.model_configuration(
+    pdf_split_child_model: self
+  )
 end

--- a/app/models/exam_paper.rb
+++ b/app/models/exam_paper.rb
@@ -19,4 +19,8 @@ class ExamPaper < DogBiscuits::ExamPaper
   before_save :combine_dates
 
   prepend OrderAlready.for(:creator)
+
+  include IiifPrint.model_configuration(
+    pdf_split_child_model: self
+  )
 end

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -12,7 +12,7 @@ class GenericWork < ActiveFedora::Base
   include AdventistMetadata
   include SlugBug
   include IiifPrint.model_configuration(
-    pdf_split_child_model: GenericWork
+    pdf_split_child_model: self
   )
 
   validates :title, presence: { message: 'Your work must have a title.' }

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -11,7 +11,9 @@ class Image < ActiveFedora::Base
   include DogBiscuits::Geo
   include DogBiscuits::PartOf
   include DogBiscuits::PlaceOfPublication
-  include IiifPrint.model_configuration
+  include IiifPrint.model_configuration(
+    pdf_split_child_model: self
+  )
 
   property :extent, predicate: ::RDF::Vocab::DC.extent, multiple: true do |index|
     index.as :stored_searchable

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -12,7 +12,10 @@ class Image < ActiveFedora::Base
   include DogBiscuits::PartOf
   include DogBiscuits::PlaceOfPublication
   include IiifPrint.model_configuration(
-    pdf_split_child_model: self
+    pdf_split_child_model: self,
+    derivative_service_plugins: [
+      IiifPrint::TextExtractionDerivativeService
+    ]
   )
 
   property :extent, predicate: ::RDF::Vocab::DC.extent, multiple: true do |index|

--- a/app/models/journal_article.rb
+++ b/app/models/journal_article.rb
@@ -24,4 +24,7 @@ class JournalArticle < DogBiscuits::JournalArticle
   before_save :combine_dates
 
   prepend OrderAlready.for(:creator)
+  include IiifPrint.model_configuration(
+    pdf_split_child_model: self
+  )
 end

--- a/app/models/published_work.rb
+++ b/app/models/published_work.rb
@@ -24,4 +24,7 @@ class PublishedWork < DogBiscuits::PublishedWork
   before_save :combine_dates
 
   prepend OrderAlready.for(:creator)
+  include IiifPrint.model_configuration(
+    pdf_split_child_model: self
+  )
 end

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -26,4 +26,7 @@ class Thesis < DogBiscuits::Thesis
   before_save :combine_dates
 
   prepend OrderAlready.for(:creator)
+  include IiifPrint.model_configuration(
+    pdf_split_child_model: self
+  )
 end


### PR DESCRIPTION
With this commit, when you split a PDF for a given model, the child model (e.g. the single page as an image) will be the given model.

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/286
- https://github.com/scientist-softserv/adventist-dl/issues/278
- #294 