### PR TITLE
`AdvSearchBuilder` inherits `IiifPrint::CatalogSearchBuilder`

### DIFF
--- a/app/search_builders/adv_search_builder.rb
+++ b/app/search_builders/adv_search_builder.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AdvSearchBuilder < Hyrax::CatalogSearchBuilder
+class AdvSearchBuilder < IiifPrint::CatalogSearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
   include BlacklightAdvancedSearch::AdvancedSearchBuilder
 

--- a/spec/search_builders/adv_search_builder_spec.rb
+++ b/spec/search_builders/adv_search_builder_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe AdvSearchBuilder do
       # :add_advanced_parse_q_to_solr, :add_advanced_search_to_solr filters.  Those existed in their
       # current position and at the end of the array.
       #
-      # When we those duplicates, the :add_advanced_parse_q_to_solr obliterated the join logic for
-      # files.
+      # When we had those duplicates, the :add_advanced_parse_q_to_solr obliterated the join logic
+      # for files.
       %i[
         default_solr_parameters
         add_query_to_solr
@@ -45,6 +45,9 @@ RSpec.describe AdvSearchBuilder do
         show_works_or_works_that_contain_files
         show_only_active_records
         filter_collection_facet_for_access
+        exclude_models
+        highlight_search_params
+        show_parents_only
       ]
     end
 


### PR DESCRIPTION
The present CatalogController configuration has the following for it's `.search_builder_class`:

```ruby
config.search_builder_class = AdvSearchBuilder
```

Prior to this commit, we did not incorporate the
`IiifPrint::CatalogSearchBuilder` search logic into the application.

With this commit, by changing `AdvSearchBuilder`'s inheritance we get the `IiifPrint::CatalogSearchBuilder` behavior that we want.

The main concern in this adjustment is that we want to ensure the order of the `default_processor_chain` is correct per the documentation of both NNP and the IiifPrint gem.

I have the following note that comes from [prior work in NNP][1] and is [documented in the IIIF Print gem][2] with the following comment:

> NOTE: If you are using advanced_search, the :exclude_models and
:highlight_search_params must be added after the advanced_search methods (which are not part of this gem).  In other tests, we found that having the advanced search processing after the two aforementioned processors resulted in improper evaluation of keyword querying.

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/287

[1]: https://github.com/scientist-softserv/nnp/blob/590d03654beb9cc483dff2923f04bab4e69be4aa/app/models/custom_search_builder.rb#L11-L14

[2]: https://github.com/scientist-softserv/iiif_print/blob/d962b86cfb64f1ad38f0def7d94ea6d326b2e2e0/lib/iiif_print/catalog_search_builder.rb#L15-L19

