### PR TITLE
Configuring to use tesseract best training data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,11 @@ RUN wget https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.0-57.t
     && rm -rf ImageMagick* \
     && rm -rf /var/cache/apk/*
 
+# Install "best" training data for Tesseract
+RUN echo "📚 Installing Tesseract Best (training data)!" && \
+    cd /usr/share/tessdata/ && \
+    wget https://github.com/tesseract-ocr/tessdata_best/blob/main/eng.traineddata?raw=true -O eng_best.traineddata
+
 ARG VIPS_VERSION=8.11.3
 
 RUN set -x -o pipefail \

--- a/config/initializers/iiif_print.rb
+++ b/config/initializers/iiif_print.rb
@@ -19,4 +19,9 @@ IiifPrint.config do |config|
   # but a different model property may be desired such as :date_published
   # @example
   #   config.sort_iiif_manifest_canvases_by = :date_published
+
+  # NOTE: As part of the docker build, we install an "eng_best".  And based on
+  #       conversations with the client, we are using --psm 1 (e.g. "Automatic
+  #       page segmentation with OSD.")
+  config.additional_tessearct_options = "-l eng_best --psm 1"
 end


### PR DESCRIPTION
Prior to this commit, we're using the default configuration for Tesseract.

In discussion with the client, we provided examples that used the better training data (as per the Tesseract documentation).  In comparing different setups they chose the configiruation to use the `-l eng_best` and the `--psm 1` configuration.

After running `docker compose build`, when we shell into the docker container and run `tesseract --list-langs` we see the following:

```bash
bash-5.1$ tesseract --list-langs
List of available languages (4):
eng
eng_best
equ
osd
```

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/248