### PR TITLE
Split PDFs into PNGs rather than TIFFs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ node_modules
 /hyrax
 
 *~undo-tree~
+.vscode/settings.json

--- a/Gemfile
+++ b/Gemfile
@@ -148,5 +148,5 @@ gem 'order_already'
 
 gem 'hyrax-v2_graph_indexer'
 # rubocop:disable Metrics/LineLength
-gem 'iiif_print', "~> 1.0", git: 'https://github.com/scientist-softserv/iiif_print.git', ref: '4d2bb726e03335cfce62309ecdcdc3de39982808'
+gem 'iiif_print', "~> 1.0", git: 'https://github.com/scientist-softserv/iiif_print.git', ref: 'cd362af6a01de7bd4176dfd8e222da756c61c340'
 # rubocop:enable Metrics/LineLength

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,8 +27,8 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: 4d2bb726e03335cfce62309ecdcdc3de39982808
-  ref: 4d2bb726e03335cfce62309ecdcdc3de39982808
+  revision: cd362af6a01de7bd4176dfd8e222da756c61c340
+  ref: cd362af6a01de7bd4176dfd8e222da756c61c340
   specs:
     iiif_print (1.0.0)
       blacklight_iiif_search (~> 1.0)

--- a/app/models/conference_item.rb
+++ b/app/models/conference_item.rb
@@ -21,6 +21,11 @@ class ConferenceItem < DogBiscuits::ConferenceItem
   prepend OrderAlready.for(:creator)
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
-    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter
+    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter,
+    derivative_service_plugins: [
+      IiifPrint::JP2DerivativeService,
+      IiifPrint::PDFDerivativeService,
+      IiifPrint::TextExtractionDerivativeService
+    ]
   )
 end

--- a/app/models/conference_item.rb
+++ b/app/models/conference_item.rb
@@ -20,6 +20,7 @@ class ConferenceItem < DogBiscuits::ConferenceItem
 
   prepend OrderAlready.for(:creator)
   include IiifPrint.model_configuration(
-    pdf_split_child_model: self
+    pdf_split_child_model: self,
+    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter
   )
 end

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -20,6 +20,7 @@ class Dataset < DogBiscuits::Dataset
 
   prepend OrderAlready.for(:creator)
   include IiifPrint.model_configuration(
-    pdf_split_child_model: self
+    pdf_split_child_model: self,
+    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter
   )
 end

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -21,6 +21,11 @@ class Dataset < DogBiscuits::Dataset
   prepend OrderAlready.for(:creator)
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
-    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter
+    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter,
+    derivative_service_plugins: [
+      IiifPrint::JP2DerivativeService,
+      IiifPrint::PDFDerivativeService,
+      IiifPrint::TextExtractionDerivativeService
+    ]
   )
 end

--- a/app/models/exam_paper.rb
+++ b/app/models/exam_paper.rb
@@ -22,6 +22,11 @@ class ExamPaper < DogBiscuits::ExamPaper
 
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
-    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter
+    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter,
+    derivative_service_plugins: [
+      IiifPrint::JP2DerivativeService,
+      IiifPrint::PDFDerivativeService,
+      IiifPrint::TextExtractionDerivativeService
+    ]
   )
 end

--- a/app/models/exam_paper.rb
+++ b/app/models/exam_paper.rb
@@ -21,6 +21,7 @@ class ExamPaper < DogBiscuits::ExamPaper
   prepend OrderAlready.for(:creator)
 
   include IiifPrint.model_configuration(
-    pdf_split_child_model: self
+    pdf_split_child_model: self,
+    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter
   )
 end

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -13,7 +13,12 @@ class GenericWork < ActiveFedora::Base
   include SlugBug
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
-    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter
+    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter,
+    derivative_service_plugins: [
+      IiifPrint::JP2DerivativeService,
+      IiifPrint::PDFDerivativeService,
+      IiifPrint::TextExtractionDerivativeService
+    ]
   )
 
   validates :title, presence: { message: 'Your work must have a title.' }

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -12,7 +12,8 @@ class GenericWork < ActiveFedora::Base
   include AdventistMetadata
   include SlugBug
   include IiifPrint.model_configuration(
-    pdf_split_child_model: self
+    pdf_split_child_model: self,
+    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter
   )
 
   validates :title, presence: { message: 'Your work must have a title.' }

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -13,6 +13,7 @@ class Image < ActiveFedora::Base
   include DogBiscuits::PlaceOfPublication
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
+    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter,
     derivative_service_plugins: [
       IiifPrint::TextExtractionDerivativeService
     ]

--- a/app/models/journal_article.rb
+++ b/app/models/journal_article.rb
@@ -25,6 +25,7 @@ class JournalArticle < DogBiscuits::JournalArticle
 
   prepend OrderAlready.for(:creator)
   include IiifPrint.model_configuration(
-    pdf_split_child_model: self
+    pdf_split_child_model: self,
+    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter
   )
 end

--- a/app/models/journal_article.rb
+++ b/app/models/journal_article.rb
@@ -26,6 +26,11 @@ class JournalArticle < DogBiscuits::JournalArticle
   prepend OrderAlready.for(:creator)
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
-    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter
+    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter,
+    derivative_service_plugins: [
+      IiifPrint::JP2DerivativeService,
+      IiifPrint::PDFDerivativeService,
+      IiifPrint::TextExtractionDerivativeService
+    ]
   )
 end

--- a/app/models/published_work.rb
+++ b/app/models/published_work.rb
@@ -25,6 +25,7 @@ class PublishedWork < DogBiscuits::PublishedWork
 
   prepend OrderAlready.for(:creator)
   include IiifPrint.model_configuration(
-    pdf_split_child_model: self
+    pdf_split_child_model: self,
+    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter
   )
 end

--- a/app/models/published_work.rb
+++ b/app/models/published_work.rb
@@ -26,6 +26,11 @@ class PublishedWork < DogBiscuits::PublishedWork
   prepend OrderAlready.for(:creator)
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
-    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter
+    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter,
+    derivative_service_plugins: [
+      IiifPrint::JP2DerivativeService,
+      IiifPrint::PDFDerivativeService,
+      IiifPrint::TextExtractionDerivativeService
+    ]
   )
 end

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -28,6 +28,11 @@ class Thesis < DogBiscuits::Thesis
   prepend OrderAlready.for(:creator)
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
-    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter
+    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter,
+    derivative_service_plugins: [
+      IiifPrint::JP2DerivativeService,
+      IiifPrint::PDFDerivativeService,
+      IiifPrint::TextExtractionDerivativeService
+    ]
   )
 end

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -27,6 +27,7 @@ class Thesis < DogBiscuits::Thesis
 
   prepend OrderAlready.for(:creator)
   include IiifPrint.model_configuration(
-    pdf_split_child_model: self
+    pdf_split_child_model: self,
+    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter
   )
 end


### PR DESCRIPTION
Refs [#293](https://github.com/scientist-softserv/adventist-dl/issues/293)

As part of IiifPrint configuration, do not create TIFF files.

TIFF files are much larger than PNG files. The resulting files should be created as PNGs rather than TIFFs. Pull Request https://github.com/scientist-softserv/iiif_print/pull/170 added the ability to configure the output files created as part of PDF splitting, and this configures all models to create PNGs rather than the default TIFFs.

Changes proposed in this pull request:
* Updates sha for iiif_print gem to pick up newest revisions
* Update configuration for all work models to split PDFs into PNGs rather than TIFFs
* Update configuration for all work models to only create non-TIFF derivatives
