### PR TITLE
add-prune-ghcr-images-after-merge-to-main

### DIFF
--- a/.github/workflows/cleanup-pr-registry-images.yaml
+++ b/.github/workflows/cleanup-pr-registry-images.yaml
@@ -1,12 +1,17 @@
 name: "Cleanup PR Registry Images"
 run-name: Pruned ${{ github.event.pull_request.head.sha }}
 on:
+  push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
     types:
       - closed
 
 jobs:
-  build:
+  delete-image:
     uses: scientist-softserv/actions/.github/workflows/cleanup-pr-registry-images.yaml@add-prune-ghcr-images-after-merge-to-main
     secrets: inherit
     with:

--- a/.github/workflows/cleanup-pr-registry-images.yaml
+++ b/.github/workflows/cleanup-pr-registry-images.yaml
@@ -7,10 +7,10 @@ on:
   inputs:
     image_name:
       description: "Docker image name part. Fills in ghcr.io/IMAGE_NAME. Typically this is the `repo_name`, but in some projects it might be `repo_name/sub_name`"
-      required: true
+      required: false
       type: string
     tag:
-      required: true
+      required: false
       type: string
     webImage:
       description: "Delete the web container registry image"

--- a/.github/workflows/cleanup-pr-registry-images.yaml
+++ b/.github/workflows/cleanup-pr-registry-images.yaml
@@ -1,0 +1,30 @@
+name: "Cleanup PR Registry Images"
+run-name: Pruned ${{ github.event.pull_request.head.sha }}
+on:
+  pull_request:
+    types:
+      - closed
+  inputs:
+    image_name:
+      description: "Docker image name part. Fills in ghcr.io/IMAGE_NAME. Typically this is the `repo_name`, but in some projects it might be `repo_name/sub_name`"
+      required: true
+      type: string
+    tag:
+      required: true
+      type: string
+    webImage:
+      description: "Delete the web container registry image"
+      required: true
+      type: boolean
+    workerImage:
+      description: "Delete the worker container registry image"
+      required: true
+      type: boolean
+
+jobs:
+  build:
+    uses: scientist-softserv/actions/.github/workflows/cleanup-pr-registry-images.yaml@add-prune-ghcr-images-after-merge-to-main
+    secrets: inherit
+    with:
+      webImage: true
+      workerImage: true

--- a/.github/workflows/cleanup-pr-registry-images.yaml
+++ b/.github/workflows/cleanup-pr-registry-images.yaml
@@ -4,22 +4,22 @@ on:
   pull_request:
     types:
       - closed
-  inputs:
-    image_name:
-      description: "Docker image name part. Fills in ghcr.io/IMAGE_NAME. Typically this is the `repo_name`, but in some projects it might be `repo_name/sub_name`"
-      required: false
-      type: string
-    tag:
-      required: false
-      type: string
-    webImage:
-      description: "Delete the web container registry image"
-      required: true
-      type: boolean
-    workerImage:
-      description: "Delete the worker container registry image"
-      required: true
-      type: boolean
+    inputs:
+      image_name:
+        description: "Docker image name part. Fills in ghcr.io/IMAGE_NAME. Typically this is the `repo_name`, but in some projects it might be `repo_name/sub_name`"
+        required: false
+        type: string
+      tag:
+        required: false
+        type: string
+      webImage:
+        description: "Delete the web container registry image"
+        required: true
+        type: boolean
+      workerImage:
+        description: "Delete the worker container registry image"
+        required: true
+        type: boolean
 
 jobs:
   build:

--- a/.github/workflows/cleanup-pr-registry-images.yaml
+++ b/.github/workflows/cleanup-pr-registry-images.yaml
@@ -4,22 +4,6 @@ on:
   pull_request:
     types:
       - closed
-    inputs:
-      image_name:
-        description: "Docker image name part. Fills in ghcr.io/IMAGE_NAME. Typically this is the `repo_name`, but in some projects it might be `repo_name/sub_name`"
-        required: false
-        type: string
-      tag:
-        required: false
-        type: string
-      webImage:
-        description: "Delete the web container registry image"
-        required: true
-        type: boolean
-      workerImage:
-        description: "Delete the worker container registry image"
-        required: true
-        type: boolean
 
 jobs:
   build:


### PR DESCRIPTION
First pass at adding the prune container image after pr closed and merged into main

Associated GHA Branch:  https://github.com/scientist-softserv/actions/pull/37