### PR TITLE
Updating iiif print gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -148,5 +148,5 @@ gem 'order_already'
 
 gem 'hyrax-v2_graph_indexer'
 # rubocop:disable Metrics/LineLength
-gem 'iiif_print', "~> 1.0", git: 'https://github.com/scientist-softserv/iiif_print.git', ref: 'cd362af6a01de7bd4176dfd8e222da756c61c340'
+gem 'iiif_print', "~> 1.0", git: 'https://github.com/scientist-softserv/iiif_print.git', ref: 'ced827e19e7f20314bdce11269ce201784b8e053'
 # rubocop:enable Metrics/LineLength

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,8 +27,8 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: cd362af6a01de7bd4176dfd8e222da756c61c340
-  ref: cd362af6a01de7bd4176dfd8e222da756c61c340
+  revision: ced827e19e7f20314bdce11269ce201784b8e053
+  ref: ced827e19e7f20314bdce11269ce201784b8e053
   specs:
     iiif_print (1.0.0)
       blacklight_iiif_search (~> 1.0)

--- a/app/models/conference_item.rb
+++ b/app/models/conference_item.rb
@@ -21,7 +21,7 @@ class ConferenceItem < DogBiscuits::ConferenceItem
   prepend OrderAlready.for(:creator)
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
-    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter,
+    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToJpgsSplitter,
     derivative_service_plugins: [
       IiifPrint::JP2DerivativeService,
       IiifPrint::PDFDerivativeService,

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -21,7 +21,7 @@ class Dataset < DogBiscuits::Dataset
   prepend OrderAlready.for(:creator)
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
-    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter,
+    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToJpgsSplitter,
     derivative_service_plugins: [
       IiifPrint::JP2DerivativeService,
       IiifPrint::PDFDerivativeService,

--- a/app/models/exam_paper.rb
+++ b/app/models/exam_paper.rb
@@ -22,7 +22,7 @@ class ExamPaper < DogBiscuits::ExamPaper
 
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
-    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter,
+    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToJpgsSplitter,
     derivative_service_plugins: [
       IiifPrint::JP2DerivativeService,
       IiifPrint::PDFDerivativeService,

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -13,7 +13,7 @@ class GenericWork < ActiveFedora::Base
   include SlugBug
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
-    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter,
+    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToJpgsSplitter,
     derivative_service_plugins: [
       IiifPrint::JP2DerivativeService,
       IiifPrint::PDFDerivativeService,

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -13,7 +13,7 @@ class Image < ActiveFedora::Base
   include DogBiscuits::PlaceOfPublication
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
-    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter,
+    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToJpgsSplitter,
     derivative_service_plugins: [
       IiifPrint::TextExtractionDerivativeService
     ]

--- a/app/models/journal_article.rb
+++ b/app/models/journal_article.rb
@@ -26,7 +26,7 @@ class JournalArticle < DogBiscuits::JournalArticle
   prepend OrderAlready.for(:creator)
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
-    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter,
+    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToJpgsSplitter,
     derivative_service_plugins: [
       IiifPrint::JP2DerivativeService,
       IiifPrint::PDFDerivativeService,

--- a/app/models/published_work.rb
+++ b/app/models/published_work.rb
@@ -26,7 +26,7 @@ class PublishedWork < DogBiscuits::PublishedWork
   prepend OrderAlready.for(:creator)
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
-    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter,
+    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToJpgsSplitter,
     derivative_service_plugins: [
       IiifPrint::JP2DerivativeService,
       IiifPrint::PDFDerivativeService,

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -28,7 +28,7 @@ class Thesis < DogBiscuits::Thesis
   prepend OrderAlready.for(:creator)
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
-    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToPngsSplitter,
+    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToJpgsSplitter,
     derivative_service_plugins: [
       IiifPrint::JP2DerivativeService,
       IiifPrint::PDFDerivativeService,


### PR DESCRIPTION
## Bumping IIIF Print gem version

dcb600b92debcec4c03d83687d09fd406d46ccea

This bump provides us with the option to split into JPGs, a method that
will even better compress images.

## Splitting pages into JPGs

da4f060c4c45d55401ba295cda2e5d04e2a9ac12

Based on https://github.com/scientist-softserv/iiif_print/pull/178:

> When I did some testing in, the PNG files are sometimes even too
> big. An example would be a 7.1MB PDF creates a 91MB TIFF or 52MB
> PNG. This is a big reduction however we can do better. Without losing
> noticeable quality, we can generate a 3.8MB JPG.

With this commit, we help further improve our compression and storage.
