### PR TITLE
Narrowing list of derivatives

### DIFF
--- a/app/models/conference_item.rb
+++ b/app/models/conference_item.rb
@@ -23,8 +23,6 @@ class ConferenceItem < DogBiscuits::ConferenceItem
     pdf_split_child_model: self,
     pdf_splitter_service: IiifPrint::SplitPdfs::PagesToJpgsSplitter,
     derivative_service_plugins: [
-      IiifPrint::JP2DerivativeService,
-      IiifPrint::PDFDerivativeService,
       IiifPrint::TextExtractionDerivativeService
     ]
   )

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -23,8 +23,6 @@ class Dataset < DogBiscuits::Dataset
     pdf_split_child_model: self,
     pdf_splitter_service: IiifPrint::SplitPdfs::PagesToJpgsSplitter,
     derivative_service_plugins: [
-      IiifPrint::JP2DerivativeService,
-      IiifPrint::PDFDerivativeService,
       IiifPrint::TextExtractionDerivativeService
     ]
   )

--- a/app/models/exam_paper.rb
+++ b/app/models/exam_paper.rb
@@ -24,8 +24,6 @@ class ExamPaper < DogBiscuits::ExamPaper
     pdf_split_child_model: self,
     pdf_splitter_service: IiifPrint::SplitPdfs::PagesToJpgsSplitter,
     derivative_service_plugins: [
-      IiifPrint::JP2DerivativeService,
-      IiifPrint::PDFDerivativeService,
       IiifPrint::TextExtractionDerivativeService
     ]
   )

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -15,8 +15,6 @@ class GenericWork < ActiveFedora::Base
     pdf_split_child_model: self,
     pdf_splitter_service: IiifPrint::SplitPdfs::PagesToJpgsSplitter,
     derivative_service_plugins: [
-      IiifPrint::JP2DerivativeService,
-      IiifPrint::PDFDerivativeService,
       IiifPrint::TextExtractionDerivativeService
     ]
   )

--- a/app/models/journal_article.rb
+++ b/app/models/journal_article.rb
@@ -28,8 +28,6 @@ class JournalArticle < DogBiscuits::JournalArticle
     pdf_split_child_model: self,
     pdf_splitter_service: IiifPrint::SplitPdfs::PagesToJpgsSplitter,
     derivative_service_plugins: [
-      IiifPrint::JP2DerivativeService,
-      IiifPrint::PDFDerivativeService,
       IiifPrint::TextExtractionDerivativeService
     ]
   )

--- a/app/models/published_work.rb
+++ b/app/models/published_work.rb
@@ -28,8 +28,6 @@ class PublishedWork < DogBiscuits::PublishedWork
     pdf_split_child_model: self,
     pdf_splitter_service: IiifPrint::SplitPdfs::PagesToJpgsSplitter,
     derivative_service_plugins: [
-      IiifPrint::JP2DerivativeService,
-      IiifPrint::PDFDerivativeService,
       IiifPrint::TextExtractionDerivativeService
     ]
   )

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -30,8 +30,6 @@ class Thesis < DogBiscuits::Thesis
     pdf_split_child_model: self,
     pdf_splitter_service: IiifPrint::SplitPdfs::PagesToJpgsSplitter,
     derivative_service_plugins: [
-      IiifPrint::JP2DerivativeService,
-      IiifPrint::PDFDerivativeService,
       IiifPrint::TextExtractionDerivativeService
     ]
   )


### PR DESCRIPTION
Prior to this commit, we were generating several derivatives that are likely unnecessary.  That, as [noted in Slack conversations][1], may result in slower processing times.

With this change, we're favoring only the text extraction and instead relying on the original files to be an adequate format.

This aligns with the proposed default configuration in:

- https://github.com/scientist-softserv/iiif_print/pull/181

[1]: https://assaydepot.slack.com/archives/C0313NJV9PE/p1678730644979469?thread_ts=1678729576.869239&cid=C0313NJV9PE
