### PR TITLE
Adding CreateDerivativesJobDecorator

### DIFF
--- a/app/jobs/create_derivatives_job_decorator.rb
+++ b/app/jobs/create_derivatives_job_decorator.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# OVERRIDE HYRAX 2.9.5 to conditionally skip derivative generation
+
+module CreateDerivativesJobDecorator
+  # @note Override to include conditional validation
+  def perform(file_set, file_id, filepath = nil)
+    return unless CreateDerivativesJobDecorator.create_derivative_for?(file_set: file_set)
+    super
+  end
+
+  # @see https://github.com/scientist-softserv/adventist-dl/issues/311 for discussion on structure
+  #      of non-Archival PDF.
+  NON_ARCHIVAL_PDF_SUFFIX = ".reader.pdf"
+
+  def self.create_derivative_for?(file_set:)
+    # Our options appear to be `file_set.label` or `file_set.original_file.original_name`; in
+    # favoring `#label` we are avoiding a call to Fedora.  Is the label likely to be the original
+    # file name?  I hope so.
+    return false if file_set.label.downcase.end_with?(NON_ARCHIVAL_PDF_SUFFIX)
+
+    true
+  end
+end
+
+CreateDerivativesJob.prepend(CreateDerivativesJobDecorator)

--- a/spec/jobs/create_derivatives_job_decorator_spec.rb
+++ b/spec/jobs/create_derivatives_job_decorator_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CreateDerivativesJobDecorator do
+  it "is prepended into CreateDerivativesJob" do
+    expect(CreateDerivativesJob.included_modules).to include(described_class)
+  end
+
+  describe '.create_derivative_for?' do
+    subject { described_class.create_derivative_for?(file_set: file_set) }
+
+    let(:file_set) { double(FileSet, label: label) }
+
+    context 'when the file set is for a non-archival PDF' do
+      let(:label) { "my-non-archival#{described_class::NON_ARCHIVAL_PDF_SUFFIX}" }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when the file set is for anything else' do
+      let(:label) { "any-other.jpg.or.pdf" }
+
+      it { is_expected.to be_truthy }
+    end
+  end
+end


### PR DESCRIPTION
Prior to this commit, we were generating derivatives for all of the PDFs.  This could be both an archival and access PDF.

And we did not need those duplicate derivatives.

With this commit, we're skipping derivative processing for any of the non-archival PDFs.

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/311

References:

- https://github.com/scientist-softserv/utk-hyku/pull/353

