### PR TITLE
Updating chrome driver

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 require 'sidekiq/web'
-Sidekiq::Web.set :session_secret, Rails.application.secrets[:secret_key_base]
 Sidekiq::Web.use AccountElevator
 
 Rails.application.routes.draw do

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -260,8 +260,17 @@ services:
       - redis:/data
     networks:
       internal:
-
   chrome:
-    image: selenium/standalone-chrome:3.141
+    # password is 'secret'
+    image: seleniarm/standalone-chromium:latest
+    logging:
+      driver: none
+    volumes:
+      - /dev/shm:/dev/shm
+    shm_size: 3G
     networks:
       internal:
+    environment:
+      - JAVA_OPTS=-Dwebdriver.chrome.whitelistedIps=
+      - VIRTUAL_PORT=7900
+      - VIRTUAL_HOST=chrome.hyku.test


### PR DESCRIPTION
## Fixing Chrome container build

d5dffabc2fde10241e7b1dd44dd353734651282b

The following commit is cribbed from Shana's work on British Library.

Related to:

- https://github.com/scientist-softserv/britishlibrary/pull/323

## Removing Sidekiq::Web.set :session_secret

86d2730fa7feed1a50c1b40bb3305ea5f4ed1a1b

Looking through the specs, I see numerous references to the following:

```shell
WARNING: Sidekiq::Web.session_secret= is no longer relevant and will be
removed in Sidekiq 7.0.
/usr/local/bundle/gems/sidekiq-6.3.1/lib/sidekiq/web.rb:75:in `set'
```

To verify that this does not break access to Sidekiq:

- Spin up a local instance
- Login as a superadmin
- Go to `/sidekiq`

You should see the sidekiq dashboard.

Derived from:

- https://github.com/scientist-softserv/britishlibrary/pull/320
