### PR TITLE
Removing author from feature spec

### DIFF
--- a/spec/features/create_conference_item_spec.rb
+++ b/spec/features/create_conference_item_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe 'Create a ConferenceItem', js: true do
       end
       click_link "Descriptions" # switch tab
       fill_in('Title', with: 'My Test Work')
-      fill_in('Author', with: 'Doe, Jane')
       fill_in('Keyword', with: 'testing')
       select('In Copyright', from: 'Rights statement')
 

--- a/spec/features/create_dataset_spec.rb
+++ b/spec/features/create_dataset_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe 'Create a Dataset', js: true do
       end
       click_link "Descriptions" # switch tab
       fill_in('Title', with: 'My Test Work')
-      fill_in('Author', with: 'Doe, Jane')
       fill_in('Keyword', with: 'testing')
       select('In Copyright', from: 'Rights statement')
 

--- a/spec/features/create_exam_paper_spec.rb
+++ b/spec/features/create_exam_paper_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe 'Create a ExamPaper', js: true do
       end
       click_link "Descriptions" # switch tab
       fill_in('Title', with: 'My Test Work')
-      fill_in('Author', with: 'Doe, Jane')
       fill_in('Keyword', with: 'testing')
       select('In Copyright', from: 'Rights statement')
 

--- a/spec/features/create_generic_work_spec.rb
+++ b/spec/features/create_generic_work_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe 'Create a GenericWork', js: true do
       end
       click_link "Descriptions" # switch tab
       fill_in('Title', with: 'My Test Work')
-      fill_in('Author', with: 'Doe, Jane')
       fill_in('Keyword', with: 'testing')
       select('In Copyright', from: 'Rights statement')
 

--- a/spec/features/create_image_spec.rb
+++ b/spec/features/create_image_spec.rb
@@ -58,7 +58,6 @@ RSpec.describe 'Create a Image', js: true do
       end
       click_link "Descriptions" # switch tab
       fill_in('Title', with: 'My Test Work')
-      fill_in('Author', with: 'Doe, Jane')
       fill_in('Keyword', with: 'testing')
       select('In Copyright', from: 'Rights statement')
 

--- a/spec/features/create_journal_article_spec.rb
+++ b/spec/features/create_journal_article_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe 'Create a JournalArticle', js: true do
       end
       click_link "Descriptions" # switch tab
       fill_in('Title', with: 'My Test Work')
-      fill_in('Author', with: 'Doe, Jane')
       fill_in('Keyword', with: 'testing')
       select('In Copyright', from: 'Rights statement')
 

--- a/spec/features/create_published_work_spec.rb
+++ b/spec/features/create_published_work_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe 'Create a PublishedWork', js: true do
       end
       click_link "Descriptions" # switch tab
       fill_in('Title', with: 'My Test Work')
-      fill_in('Author', with: 'Doe, Jane')
       fill_in('Keyword', with: 'testing')
       select('In Copyright', from: 'Rights statement')
 

--- a/spec/features/create_thesis_spec.rb
+++ b/spec/features/create_thesis_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe 'Create a Thesis', js: true do
       end
       click_link "Descriptions" # switch tab
       fill_in('Title', with: 'My Test Work')
-      fill_in('Author', with: 'Doe, Jane')
       fill_in('Keyword', with: 'testing')
       select('In Copyright', from: 'Rights statement')
 


### PR DESCRIPTION
The author is not required nor visible, so we need not provide it.

This does not get all specs passing, but does eliminate a handful of failures.