### PR TITLE
Update iiif_print gem to fix child works sequence

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -148,5 +148,5 @@ gem 'order_already'
 
 gem 'hyrax-v2_graph_indexer'
 # rubocop:disable Metrics/LineLength
-gem 'iiif_print', "~> 1.0", git: 'https://github.com/scientist-softserv/iiif_print.git', ref: 'ced827e19e7f20314bdce11269ce201784b8e053'
+gem 'iiif_print', "~> 1.0", git: 'https://github.com/scientist-softserv/iiif_print.git', ref: 'e3384284a9992df867b7bedc256c82485355551d'
 # rubocop:enable Metrics/LineLength

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,8 +27,8 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: ced827e19e7f20314bdce11269ce201784b8e053
-  ref: ced827e19e7f20314bdce11269ce201784b8e053
+  revision: e3384284a9992df867b7bedc256c82485355551d
+  ref: e3384284a9992df867b7bedc256c82485355551d
   specs:
     iiif_print (1.0.0)
       blacklight_iiif_search (~> 1.0)


### PR DESCRIPTION
# Story

Sorting of child works split from a PDF was not handling page numbers correctly. This PR brings in the [iiif_print fix](https://github.com/scientist-softserv/iiif_print/pull/197).

ref https://github.com/scientist-softserv/adventist-dl/issues/323

# Expected Behavior Before Changes

If a PDF has more than 9 pages, the child works will not be sequenced correctly.

# Expected Behavior After Changes

Page numbers are padded to sequence the child works correctly.

# Screenshots / Video

<details>
<summary>Screenshot after update</summary>

![Screenshot 2023-03-22 at 2 28 47 PM](https://user-images.githubusercontent.com/17851674/227002645-3635d250-721e-48f8-8f74-13f4d1c705ff.png)
</details>

# Notes