### PR TITLE
[i326] - update iiif_print

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -147,6 +147,5 @@ gem 'dog_biscuits', git: 'https://github.com/samvera-labs/dog_biscuits.git'
 gem 'order_already'
 
 gem 'hyrax-v2_graph_indexer'
-# rubocop:disable Metrics/LineLength
 gem 'iiif_print', "~> 1.0", git: 'https://github.com/scientist-softserv/iiif_print.git', branch: 'main'
 # rubocop:enable Metrics/LineLength

--- a/Gemfile
+++ b/Gemfile
@@ -148,5 +148,5 @@ gem 'order_already'
 
 gem 'hyrax-v2_graph_indexer'
 # rubocop:disable Metrics/LineLength
-gem 'iiif_print', "~> 1.0", git: 'https://github.com/scientist-softserv/iiif_print.git', ref: 'ced827e19e7f20314bdce11269ce201784b8e053'
+gem 'iiif_print', "~> 1.0", git: 'https://github.com/scientist-softserv/iiif_print.git', branch: 'main'
 # rubocop:enable Metrics/LineLength

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,8 +27,8 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: ced827e19e7f20314bdce11269ce201784b8e053
-  ref: ced827e19e7f20314bdce11269ce201784b8e053
+  revision: e3384284a9992df867b7bedc256c82485355551d
+  branch: main
   specs:
     iiif_print (1.0.0)
       blacklight_iiif_search (~> 1.0)


### PR DESCRIPTION
I was able to reproduce this issue. When I updated the gem, it started to work again.

# Story

Refs https://github.com/scientist-softserv/adventist-dl/issues/326

# Expected Behavior Before Changes

Adding an work to a collection prevented the UV from rendering any images

# Expected Behavior After Changes

Adding a work to a collection no longer gives 500 internal error

 https://adl.s2.adventistdigitallibrary.org/concern/images/86e6afad-c3b6-4094-ab48-2d553af710e0?locale=en