### PR TITLE
Ensure we don't split `.reader.pdf` files

### DIFF
--- a/app/models/conference_item.rb
+++ b/app/models/conference_item.rb
@@ -21,7 +21,7 @@ class ConferenceItem < DogBiscuits::ConferenceItem
   prepend OrderAlready.for(:creator)
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
-    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToJpgsSplitter,
+    pdf_splitter_service: IiifPrint::SplitPdfs::AdventistPagesToJpgsSplitter,
     derivative_service_plugins: [
       IiifPrint::TextExtractionDerivativeService
     ]

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -21,7 +21,7 @@ class Dataset < DogBiscuits::Dataset
   prepend OrderAlready.for(:creator)
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
-    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToJpgsSplitter,
+    pdf_splitter_service: IiifPrint::SplitPdfs::AdventistPagesToJpgsSplitter,
     derivative_service_plugins: [
       IiifPrint::TextExtractionDerivativeService
     ]

--- a/app/models/exam_paper.rb
+++ b/app/models/exam_paper.rb
@@ -22,7 +22,7 @@ class ExamPaper < DogBiscuits::ExamPaper
 
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
-    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToJpgsSplitter,
+    pdf_splitter_service: IiifPrint::SplitPdfs::AdventistPagesToJpgsSplitter,
     derivative_service_plugins: [
       IiifPrint::TextExtractionDerivativeService
     ]

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -13,7 +13,7 @@ class GenericWork < ActiveFedora::Base
   include SlugBug
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
-    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToJpgsSplitter,
+    pdf_splitter_service: IiifPrint::SplitPdfs::AdventistPagesToJpgsSplitter,
     derivative_service_plugins: [
       IiifPrint::TextExtractionDerivativeService
     ]

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -13,7 +13,7 @@ class Image < ActiveFedora::Base
   include DogBiscuits::PlaceOfPublication
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
-    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToJpgsSplitter,
+    pdf_splitter_service: IiifPrint::SplitPdfs::AdventistPagesToJpgsSplitter,
     derivative_service_plugins: [
       IiifPrint::TextExtractionDerivativeService
     ]

--- a/app/models/journal_article.rb
+++ b/app/models/journal_article.rb
@@ -26,7 +26,7 @@ class JournalArticle < DogBiscuits::JournalArticle
   prepend OrderAlready.for(:creator)
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
-    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToJpgsSplitter,
+    pdf_splitter_service: IiifPrint::SplitPdfs::AdventistPagesToJpgsSplitter,
     derivative_service_plugins: [
       IiifPrint::TextExtractionDerivativeService
     ]

--- a/app/models/published_work.rb
+++ b/app/models/published_work.rb
@@ -26,7 +26,7 @@ class PublishedWork < DogBiscuits::PublishedWork
   prepend OrderAlready.for(:creator)
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
-    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToJpgsSplitter,
+    pdf_splitter_service: IiifPrint::SplitPdfs::AdventistPagesToJpgsSplitter,
     derivative_service_plugins: [
       IiifPrint::TextExtractionDerivativeService
     ]

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -28,7 +28,7 @@ class Thesis < DogBiscuits::Thesis
   prepend OrderAlready.for(:creator)
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
-    pdf_splitter_service: IiifPrint::SplitPdfs::PagesToJpgsSplitter,
+    pdf_splitter_service: IiifPrint::SplitPdfs::AdventistPagesToJpgsSplitter,
     derivative_service_plugins: [
       IiifPrint::TextExtractionDerivativeService
     ]

--- a/config/initializers/iiif_print.rb
+++ b/config/initializers/iiif_print.rb
@@ -25,3 +25,5 @@ IiifPrint.config do |config|
   #       page segmentation with OSD.")
   config.additional_tessearct_options = "-l eng_best --psm 1"
 end
+
+require "iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter"

--- a/lib/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter.rb
+++ b/lib/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module IiifPrint
+  module SplitPdfs
+    module AdventistPagesToJpgsSplitter
+      ##
+      # We do not always want to split a PDF; this provides a decision point.
+      #
+      # @param path [String] the path of the file we're attempting to run derivatives against.
+      # @param args [Array<Object>] pass through args
+      # @param splitter [IiifPrint::SplitPdfs::BaseSplitter] (for dependency injection)
+      # @param suffix [String] (for dependency injection)
+      #
+      # @return [#to_a] when we are going to skip splitting, return an empty array; otherwise return
+      #         an instance of {IiifPrint::SplitPdfs::AdventistPagesToJpgsSplitter}.
+      # @note I am adding a {.new} method to a module to mimic the instantiation of a class.
+      #
+      # @see https://github.com/scientist-softserv/iiif_print/blob/a23706453f23e0f54c9d50bbf0ddf9311d82a0b9/lib/iiif_print/jobs/child_works_from_pdf_job.rb#L39-L63
+      # rubocop:disable Metrics/LineLength
+      def self.new(path, *args, splitter: PagesToJpgsSplitter, suffix: CreateDerivativesJobDecorator::NON_ARCHIVAL_PDF_SUFFIX)
+        if path.downcase.end_with?(suffix)
+          # The public interface of a Splitter is something that responds to #to_a / #each.
+          []
+        else
+          splitter.new(path, *args)
+        end
+      end
+      # rubocop:enable Metrics/LineLength
+    end
+  end
+end

--- a/spec/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter_spec.rb
+++ b/spec/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe IiifPrint::SplitPdfs::AdventistPagesToJpgsSplitter do
+  describe '.new' do
+    subject { described_class.new(path, suffix: "spec.rb", splitter: splitter) }
+
+    let(:splitter) { Class.new { def initialize(path); end } }
+
+    context 'when given path ends in the given suffix' do
+      let(:path) { __FILE__ }
+
+      it { is_expected.to eq([]) }
+    end
+
+    context 'when given path does not end in the suffix' do
+      let(:path) { "#{__FILE__}.hello.rb" }
+
+      it { is_expected.to be_a(splitter) }
+    end
+  end
+end


### PR DESCRIPTION
Prior to this commit, we skipped generating derivatives on the `.reader.pdf` (see [313]).  However, we also wanted to avoid splitting the reader PDFs.

With this commit, we now have logic that avoids splitting `.reader.pdf` files into constituent pages.

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/286
- https://github.com/scientist-softserv/adventist-dl/issues/311

[313]: https://github.com/scientist-softserv/adventist-dl/pull/313

