### PR TITLE
Hyku reset task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,7 +91,7 @@ end
 
 # rubocop:disable Metrics/LineLength
 # Bulkrax :: While we technically don't need a version when we tag on the branch, this helps us have a quick scan of what version we're assuming/working with.
-gem 'bulkrax', "~> 5.1.0", git: 'https://github.com/samvera-labs/bulkrax.git', ref: '4a04f8b9b19af78f75d286dd2d78516fe4cf474e'
+gem 'bulkrax', "~> 5.1.0", git: 'https://github.com/samvera-labs/bulkrax.git', ref: '2bb4b6170a211a8cc5aa5999386b5efcea762277'
 # rubocop:enable Metrics/LineLength
 
 gem 'blacklight', '~> 6.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/samvera-labs/bulkrax.git
-  revision: 4a04f8b9b19af78f75d286dd2d78516fe4cf474e
-  ref: 4a04f8b9b19af78f75d286dd2d78516fe4cf474e
+  revision: 2bb4b6170a211a8cc5aa5999386b5efcea762277
+  ref: 2bb4b6170a211a8cc5aa5999386b5efcea762277
   specs:
     bulkrax (5.1.0)
       bagit (~> 0.4)

--- a/lib/tasks/reset.rake
+++ b/lib/tasks/reset.rake
@@ -1,0 +1,30 @@
+namespace :reset do
+    desc 'reset work and collection data across all tenants'
+    task all_works_and_collections: [:environment] do
+      confirm('You are about to delete all works and collections across all accounts, this is not reversable!')
+      Account.find_each do |account|
+        switch!(account)
+        Rake::Task["hyrax:reset:works_and_collections"].reenable
+        Rake::Task["hyrax:reset:works_and_collections"].invoke
+      end
+    end
+  
+    desc 'reset work and collection data from a single tenant, any argument that works with switch!() will work here'
+    task :works_and_collections, [:account] => [:environment] do |t, args|
+      raise "You must speficy a name, cname or id of an account" if args[:account].blank?
+      
+      confirm('You are about to delete all works and collections from #{args[:account]}, this is not reversable!')
+      switch!(args[:account])
+      Rake::Task["hyrax:reset:works_and_collections"].reenable
+      Rake::Task["hyrax:reset:works_and_collections"].invoke
+    end
+  
+    def confirm(action)
+      return if ENV['RESET_CONFIRMED'].present?
+      confirm_token = rand(36**6).to_s(36)
+      STDOUT.puts "#{action} Enter '#{confirm_token}' to confirm:"
+      input = STDIN.gets.chomp
+      raise "Aborting. You entered #{input}" unless input == confirm_token
+      ENV['RESET_CONFIRMED'] = 'true'
+    end
+  end


### PR DESCRIPTION
# Story

This PR pulls in the reset.rake task from a higher version of hyku. It will allow us to run a script to easily delete the data in a system. 


# Expected Behavior Before Changes

We'd have to manually do this and deal with shared resources in rancher. 

# Expected Behavior After Changes

We can run either script in the server's console: 
```
rake reset:all_works_and_collections       # reset work and collection data across all tenants
rake reset:works_and_collections[account]  # reset work and collection data from a single tenant, any argument that works with switch
```


# Screenshots / Video

I imported data into two tenants: dev and demo. 

I ran the second rake task to delete the data on the dev tenant only. 

**AFTER:** 

demo's data is still present
![image](https://user-images.githubusercontent.com/10081604/227375889-66fd3422-8e5c-4d43-b2dc-0d2c7cdcedff.png)

dev's data is gone

![image](https://user-images.githubusercontent.com/10081604/227375963-b0b075c9-98d7-416a-af69-0b69140465fd.png)



# Notes