### PR TITLE
Load custom splitter earlier

### DIFF
--- a/app/jobs/create_derivatives_job_decorator.rb
+++ b/app/jobs/create_derivatives_job_decorator.rb
@@ -11,13 +11,13 @@ module CreateDerivativesJobDecorator
 
   # @see https://github.com/scientist-softserv/adventist-dl/issues/311 for discussion on structure
   #      of non-Archival PDF.
-  NON_ARCHIVAL_PDF_SUFFICES = [".reader.pdf", ".pdf-r.pdf"]
+  NON_ARCHIVAL_PDF_SUFFIXES = [".reader.pdf", ".pdf-r.pdf"].freeze
 
   def self.create_derivative_for?(file_set:)
     # Our options appear to be `file_set.label` or `file_set.original_file.original_name`; in
     # favoring `#label` we are avoiding a call to Fedora.  Is the label likely to be the original
     # file name?  I hope so.
-    return false if NON_ARCHIVAL_PDF_SUFFICES.include?(file_set.label.downcase)
+    return false if NON_ARCHIVAL_PDF_SUFFIXES.include?(file_set.label.downcase)
 
     true
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,10 @@ module Hyku
   end
 
   class Application < Rails::Application
+    # Add this line to load the lib folder first because we need
+    # IiifPrint::SplitPdfs::AdventistPagesToJpgsSplitter
+    config.autoload_paths.unshift("#{Rails.root}/lib")
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/lib/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter.rb
+++ b/lib/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter.rb
@@ -17,13 +17,10 @@ module IiifPrint
       #
       # @see https://github.com/scientist-softserv/iiif_print/blob/a23706453f23e0f54c9d50bbf0ddf9311d82a0b9/lib/iiif_print/jobs/child_works_from_pdf_job.rb#L39-L63
       # rubocop:disable Metrics/LineLength
-      def self.new(path, *args, splitter: PagesToJpgsSplitter, suffix: CreateDerivativesJobDecorator::NON_ARCHIVAL_PDF_SUFFIX)
-        if path.downcase.end_with?(suffix)
-          # The public interface of a Splitter is something that responds to #to_a / #each.
-          []
-        else
-          splitter.new(path, *args)
-        end
+      def self.new(path, *args, splitter: PagesToJpgsSplitter, suffixes: CreateDerivativesJobDecorator::NON_ARCHIVAL_PDF_SUFFIXES)
+        return [] if suffixes.any? { |suffix| path.downcase.end_with?(suffix) }
+
+        splitter.new(path, *args)
       end
       # rubocop:enable Metrics/LineLength
     end


### PR DESCRIPTION
ref: #286 

This commit moves the loading of the lib path earlier so the models will know about the custom splitter.  Also adjusted the logic in `AdventistPagesToJpgsSplitter.new` to work with arrays.

PDF with a child page:
![image](https://user-images.githubusercontent.com/19597776/228629146-e4266811-f357-45c3-bd10-02170261bfb3.png)

Searching for the title yields one result:
![image](https://user-images.githubusercontent.com/19597776/228629358-c3406b65-9588-40ac-bc9e-d733daf8c4b6.png)
