### PR TITLE
Updating hyrax-v2_graph_indexer to 0.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -146,6 +146,6 @@ gem 'dog_biscuits', git: 'https://github.com/samvera-labs/dog_biscuits.git'
 
 gem 'order_already'
 
-gem 'hyrax-v2_graph_indexer'
+gem 'hyrax-v2_graph_indexer', '~> 0.3'
 gem 'iiif_print', "~> 1.0", git: 'https://github.com/scientist-softserv/iiif_print.git', branch: 'main'
 # rubocop:enable Metrics/LineLength

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -538,7 +538,7 @@ GEM
       signet
       solrizer (>= 3.4, < 5)
       tinymce-rails (~> 4.1)
-    hyrax-v2_graph_indexer (0.1.0)
+    hyrax-v2_graph_indexer (0.3.0)
       hyrax (~> 2.9)
       railties
     i18n (1.8.11)
@@ -1142,7 +1142,7 @@ DEPENDENCIES
   flipflop (~> 2.3)
   flutie
   hyrax (~> 2.9, >= 2.9.1)
-  hyrax-v2_graph_indexer
+  hyrax-v2_graph_indexer (~> 0.3)
   i18n-debug
   i18n-tasks
   iiif_print (~> 1.0)!


### PR DESCRIPTION
This update has been tested against British Library and includes fixes in how the module decoration/overrides were defined.

Thank you LaRita for noticing that the job was in the Sidekiq queue.
