### PR TITLE
Update iiif_print & set child work title config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -147,4 +147,6 @@ gem 'dog_biscuits', git: 'https://github.com/samvera-labs/dog_biscuits.git'
 gem 'order_already'
 
 gem 'hyrax-v2_graph_indexer'
+# rubocop:disable Metrics/LineLength
 gem 'iiif_print', "~> 1.0", git: 'https://github.com/scientist-softserv/iiif_print.git', ref: '68bcc27db0f464e04db79f244e5552bd001cc735'
+# rubocop:enable Metrics/LineLength

--- a/Gemfile
+++ b/Gemfile
@@ -147,4 +147,4 @@ gem 'dog_biscuits', git: 'https://github.com/samvera-labs/dog_biscuits.git'
 gem 'order_already'
 
 gem 'hyrax-v2_graph_indexer'
-gem 'iiif_print', "~> 1.0", git: 'https://github.com/scientist-softserv/iiif_print.git', ref: '97be189'
+gem 'iiif_print', "~> 1.0", git: 'https://github.com/scientist-softserv/iiif_print.git', ref: '68bcc27db0f464e04db79f244e5552bd001cc735'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,8 +27,8 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: 97be189e30ac002c1beb829f0cb5388a22a38523
-  ref: 97be189
+  revision: 68bcc27db0f464e04db79f244e5552bd001cc735
+  ref: 68bcc27db0f464e04db79f244e5552bd001cc735
   specs:
     iiif_print (1.0.0)
       blacklight_iiif_search (~> 1.0)
@@ -1142,7 +1142,7 @@ DEPENDENCIES
   flipflop (~> 2.3)
   flutie
   hyrax (~> 2.9, >= 2.9.1)
-  hyrax-v2_graph_indexer (~> 0.3)
+  hyrax-v2_graph_indexer
   i18n-debug
   i18n-tasks
   iiif_print (~> 1.0)!

--- a/config/initializers/iiif_print.rb
+++ b/config/initializers/iiif_print.rb
@@ -23,6 +23,21 @@ IiifPrint.config do |config|
   # NOTE: As part of the docker build, we install an "eng_best".  And based on
   #       conversations with the client)
   config.additional_tessearct_options = "-l eng_best"
+
+  # def unique_child_title_generator_function
+  #   @unique_child_title_generator_function ||= lambda { |original_pdf_path:, image_path:, parent_work:, page_number:, page_padding:|
+  #     identifier = parent_work.id
+  #     filename = File.basename(original_pdf_path)
+  #     page_suffix = "Page #{(page_number.to_i + 1).to_s.rjust(page_padding.to_i, '0')}"
+  #     "#{identifier} - #{filename} #{page_suffix}"
+  #   }
+  # end
+  config.unique_child_title_generator_function = lambda { |original_pdf_path:, parent_work:, page_number:, page_padding:, **| 
+    identifier = parent_work.to_param # ref Slug Bug
+    filename = File.basename(original_pdf_path)
+    page_suffix = "Page #{(page_number.to_i + 1).to_s.rjust(page_padding.to_i, '0')}"
+    "#{identifier} || #{filename} #{page_suffix}"
+  }
 end
 
 require "iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter"


### PR DESCRIPTION
# Story

Duplicate parent work titles were causing the child works to get duplicate titles, since the titles were based on the parent work's title. This results in child works not all getting attached to the parent work or potentially getting attached to the wrong parent. 

With this pull request, we revise the child work title to use the new config option from iiif_print. The resulting title gets built as `parent_work_slug || filename_of_split.pdf Page 01`. This ensures a unique child work title, and also creates a visual connection to the pdf it was split from.

Refs #286 https://github.com/scientist-softserv/iiif_print/issues/204

# Expected Behavior After Changes
Child work titles are now unique.

# Screenshots / Video

<details>
<summary>Example of child works from dashboard view</summary>

![Screenshot 2023-04-05 at 5 34 23 PM](https://user-images.githubusercontent.com/17851674/230219205-8dd541f0-d69b-4d77-938c-9a059fb28ef8.png)
</details>

# Notes