### PR TITLE
need solr url set properly during tenant creation

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -153,6 +153,8 @@ extraEnvVars: &envVars
     value: "8983"
   - name: SOLR_URL
     value: http://admin:$SOLR_ADMIN_PASSWORD@solr.default:8983/solr/
+  - name: SETTINGS__SOLR__URL
+    value: http://admin:$SOLR_ADMIN_PASSWORD@solr.default:8983/solr/
   - name: SMTP_ENABLED
     value: "true"
   - name: SMTP_USER_NAME

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -140,6 +140,8 @@ extraEnvVars: &envVars
     value: "8983"
   - name: SOLR_URL
     value: http://admin:$SOLR_ADMIN_PASSWORD@solr.staging-solr:8983/solr/
+  - name: SETTINGS__SOLR__URL
+    value: http://admin:$SOLR_ADMIN_PASSWORD@solr.staging-solr:8983/solr/
   - name: SMTP_ENABLED
     value: "true"
   - name: SMTP_USER_NAME


### PR DESCRIPTION
Ref #71 

Note you will still need to add the tenant URL to the ingress section in `ops/staging-deploy.tmpl.yaml` or `ops/production-deploy.tmpl.yaml` as we do not have the ability to issue wildcard certs. the actual name (acme.b2.adventistdigitallibrary.org for example) has to be in the `ops/production-deploy.tmpl.yaml` and then deployed for it to work.