### PR TITLE
Fix typo: McReady becomes McCready in collection title

### DIFF
--- a/app/views/adl/_featured_collections.html.erb
+++ b/app/views/adl/_featured_collections.html.erb
@@ -7,7 +7,7 @@
         <div class="collection-thumbnail">
           <%= image_tag('adl-featured-collections/george-mccready-price.jpg', alt: "George McReady Price Papers") %>
           <div class="collection-info px-4 py-4">
-            <h3 class="collection-title">George McReady Price Papers</h3>
+            <h3 class="collection-title">George McCready Price Papers</h3>
             <p class="collection-description">The Price collection contains correspondence, manuscripts, articles and poems written by Mr. Price, his wife, and others during the course of his life.</p>
           </div>
         </div>


### PR DESCRIPTION
# Story

Refs #338 ([QA from client](https://github.com/scientist-softserv/adventist-dl/issues/338#issuecomment-1499127060))

# Expected Behavior Before Changes

![example](https://user-images.githubusercontent.com/17851674/230411961-aef760b8-6797-4a08-9d8d-bb14821b3c06.png)

# Expected Behavior After Changes

Text outlined in yellow from above image now says McCready
![Screenshot 2023-04-06 at 10 41 51 AM](https://user-images.githubusercontent.com/17851674/230414053-21c25491-d5ff-47eb-9960-4dde57a8b21c.png)

# Notes