### PR TITLE
Fixing arity mismatch for ImportUrlJob#send_error

### DIFF
--- a/app/jobs/import_url_job_decorator.rb
+++ b/app/jobs/import_url_job_decorator.rb
@@ -1,0 +1,11 @@
+# OVERRIDE in v2.9.6 of Hyrax
+module ImportUrlJobDecorator
+  # OVERRIDE there are calls to send_error that send two arguments.
+  #
+  # @see https://github.com/samvera/hyrax/blob/426575a9065a5dd3b30f458f5589a0a705ad7be2/app/jobs/import_url_job.rb#L76-L105
+  def send_error(error_message, *args)
+    super(error_message)
+  end
+end
+
+ImportUrlJob.prepend(ImportUrlJobDecorator)

--- a/app/jobs/import_url_job_decorator.rb
+++ b/app/jobs/import_url_job_decorator.rb
@@ -1,9 +1,34 @@
+# frozen_string_literal: true
+
 # OVERRIDE in v2.9.6 of Hyrax
 module ImportUrlJobDecorator
+  # OVERRIDE to gain further insight into the StandardError that was reported but hidden.
+  def copy_remote_file(uri, name, headers = {})
+    filename = File.basename(name)
+    dir = Dir.mktmpdir
+    Rails.logger.debug("ImportUrlJob: Copying <#{uri}> to #{dir}")
+
+    File.open(File.join(dir, filename), 'wb') do |f|
+      begin
+        write_file(uri, f, headers)
+        yield f
+      rescue StandardError => e
+        # OVERRIDE adding Rails.logger.error call
+        Rails.logger.error(
+          %(ImportUrlJob: Error copying <#{uri}> to #{dir} with #{e.message}.  #{e.backtrace.join("\n")})
+        )
+        send_error(e.message)
+        # TODO: Should we re-raise the exception?  As written this copy_remote_file has a false
+        # success.
+      end
+    end
+    Rails.logger.debug("ImportUrlJob: Copying <#{uri}> to #{dir}, closing #{File.join(dir, filename)}")
+  end
+
   # OVERRIDE there are calls to send_error that send two arguments.
   #
   # @see https://github.com/samvera/hyrax/blob/426575a9065a5dd3b30f458f5589a0a705ad7be2/app/jobs/import_url_job.rb#L76-L105
-  def send_error(error_message, *args)
+  def send_error(error_message, *)
     super(error_message)
   end
 end


### PR DESCRIPTION
## Fixing arity mismatch for ImportUrlJob#send_error

7b215842c0845bb7e1875a0dbc957e1b06830843

In v2.9.6 of Hyrax we saw the following error:

> File Import Error
>   Error: wrong number of arguments (given 2, expected 1)

It masks other errors, because the message sending for errors is itself
raising an error.

With this change, we ignore all extra parameters and pass the first
parameter.

Related to:

- https://github.com/samvera/hyrax/pull/2821

Resolved in:

- https://github.com/samvera/hyrax/pull/4243
- https://github.com/samvera/hyrax/commit/bfd316e23b5bfbf8d811e8a8dd582c1a2529887b

## Adding logging for muted exception

811b738f099d48dfb8d7db1911f1c26ec80e0c1a

Prior to this commit, we were taking an exception and passing just the
message to the user.  We abandoned the useful backtrace and context.

With this commit, we add error logging of the back trace.

An outstanding question is "What would be the consequence of re-raising
the exception?"  Would this help us gain better insight into what's
going on?  It seems like we probably should do that.
