### PR TITLE
Embargo lease issue

### DIFF
--- a/app/jobs/embargo_auto_expiry_job.rb
+++ b/app/jobs/embargo_auto_expiry_job.rb
@@ -7,7 +7,7 @@ class EmbargoAutoExpiryJob < ApplicationJob
   end
 
   def perform(account)
-    account.switch do
+    Apartment::Tenant.switch(account.tenant) do
       # From Hyrax app/jobs/embargo_expiry_job
       EmbargoExpiryJob.perform_now
     end

--- a/app/jobs/lease_auto_expiry_job.rb
+++ b/app/jobs/lease_auto_expiry_job.rb
@@ -7,7 +7,7 @@ class LeaseAutoExpiryJob < ApplicationJob
   end
 
   def perform(account)
-    account.switch do
+    Apartment::Tenant.switch(account.tenant) do
       # From Hyrax app/jobs/lease_expiry_job
       LeaseExpiryJob.perform_now
     end

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -2,11 +2,11 @@ replicaCount: 2
 
 resources:
   requests:
-    memory: "1Gi"
-    cpu: "250m"
-  limits:
-    memory: "2Gi"
+    memory: "4Gi"
     cpu: "1000m"
+  limits:
+    memory: "4Gi"
+    cpu: "2000m"
 
 livenessProbe:
   enabled: false

--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
   factory :redis_endpoint do
     options { Hash.new(namespace: 'fakeNS') }
   end
+
   factory :account do
     sequence(:name) { |_n| srand }
 
@@ -23,7 +24,14 @@ FactoryBot.define do
     after(:create) do |account, evaluator|
       create_list(:domain_name, evaluator.domain_names_count, account: account)
     end
+
+    trait(:public_schema) do
+      tenant { 'public' }
+    end
+
+    factory :account_with_public_schema, traits: [:public_schema]
   end
+
   factory :sign_up_account, class: Account do
     sequence(:name) { |_n| srand }
 

--- a/spec/jobs/embargo_auto_expiry_job_spec.rb
+++ b/spec/jobs/embargo_auto_expiry_job_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe EmbargoAutoExpiryJob do
   let(:past_date) { 2.days.ago }
   let(:future_date) { 2.days.from_now }
 
-  let(:account) { create(:account) }
+  let(:account) { create(:account_with_public_schema) }
 
   let!(:embargoed_work) do
     build(:work, embargo_release_date: future_date.to_s,

--- a/spec/jobs/lease_auto_expiry_job_spec.rb
+++ b/spec/jobs/lease_auto_expiry_job_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe LeaseAutoExpiryJob do
   let(:past_date) { 2.days.ago }
   let(:future_date) { 2.days.from_now }
 
-  let(:account) { create(:account) }
+  let(:account) { create(:account_with_public_schema) }
 
   let!(:leased_work) do
     build(:work, lease_expiration_date: future_date.to_s,


### PR DESCRIPTION
There was a bug where in development, embargo and lease jobs would have an infinite loop when first being created. this has been resolved in other Hyku instances.