### PR TITLE
Adding peer_reviewed to importer and AdventistMetadata

### DIFF
--- a/app/models/adventist_metadata.rb
+++ b/app/models/adventist_metadata.rb
@@ -48,6 +48,12 @@ module AdventistMetadata
       index.as :stored_searchable, :facetable
     end
 
+    # Creating an arbitrary URL for this predicate.  It may not resolve.  We're expecting the value
+    # "Peer Reviewed" or no value.
+    property :peer_reviewed, predicate: ::RDF::URI.new('http://adventist.org/rdf-vocab/peerReviewed') do |index|
+      index.as :facetable
+    end
+
     id_blank = proc { |attributes| attributes[:id].blank? }
 
     class_attribute :controlled_properties

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -65,7 +65,8 @@ if Settings.bulkrax.enabled
         'location' => { from: ['location'], split: ';' },
         'model' => { from: ['model', 'work_type'] },
         'remote_files' => { from: ['related_url'], split: ';', parsed: true },
-        'thumbnail_url' => { from: ['thumbnail_url'], default_thumbnail: true, parsed: true }
+        'thumbnail_url' => { from: ['thumbnail_url'], default_thumbnail: true, parsed: true },
+        'peer_reviewed' => { from: ['peer_reviewed'] }
     }
     config.field_mappings['Bulkrax::CsvParser'] = {
         'abstract' => { from:  ['description.abstract'] },
@@ -98,7 +99,8 @@ if Settings.bulkrax.enabled
         'model' => { from: ['work_type'] },
         'remote_files' => { from: ['related_url'], split: ';', parsed: true },
         'remote_url' => { from: ['official_url', 'remote_url'], split: ';' },
-        'thumbnail_url' => { from: ['thumbnail_url'], default_thumbnail: true, parsed: true }
+        'thumbnail_url' => { from: ['thumbnail_url'], default_thumbnail: true, parsed: true },
+        'peer_reviewed' => { from: ['peer_reviewed'] }
     }
 
     # Lambda to set the default field mapping

--- a/spec/models/bulkrax/oai_adventist_qdc_entry_spec.rb
+++ b/spec/models/bulkrax/oai_adventist_qdc_entry_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe Bulkrax::OaiAdventistQdcEntry do
                 <subject>Charity -- Dress Reform -- Spiritualism; Civil War, 1861-1865 -- Slavery; History; Visions -- Censures; White, Ellen Gould Harmon, 1827-1915</subject>
                 <pagination>[16]</pagination>
                 <volume_number>178</volume_number>
+                <peer_reviewed>Peer Reviewed</peer_reviewed>
                 <location>Somewhere over the rainbow</location>
                 <work_type>#{work_type}</work_type>
                   </oai_adl>
@@ -77,6 +78,7 @@ RSpec.describe Bulkrax::OaiAdventistQdcEntry do
         expect(entry.parsed_metadata.fetch('location')).to eq(["Somewhere over the rainbow"])
         expect(entry.parsed_metadata.fetch('identifier')).to eq([identifier])
         expect(entry.parsed_metadata.fetch('edition')).to eq(["Revised"])
+        expect(entry.parsed_metadata.fetch('peer_reviewed')).to eq(["Peer Reviewed"])
 
         expect(entry.parsed_metadata.fetch('publisher')).to eq(
           ["Steam Press of the Seventh-Day Adventist Publishing Association", "Other Publisher"]
@@ -106,6 +108,7 @@ RSpec.describe Bulkrax::OaiAdventistQdcEntry do
         expect(entry.parsed_metadata.fetch('volume_number')).to eq(["178"])
         expect(entry.parsed_metadata.fetch('location')).to eq(["Somewhere over the rainbow"])
         expect(entry.parsed_metadata.fetch('identifier')).to eq([identifier])
+        expect(entry.parsed_metadata.fetch('peer_reviewed')).to eq(["Peer Reviewed"])
       end
     end
   end


### PR DESCRIPTION
> We'd like to see the Peer Review field on Hyku be filled or left blank in
> response to this metadata, and we'd like users to be able to filter by a Peer
> Review facet. Can we add this as a ticket? We will hold off a major reload of
> the repository until the Peer Review information can come in, so if we need to
> wait for the next sprint then this would be a high priority at that time.

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/185

# Story

Refs #issuenumber

# Expected Behavior Before Changes

# Expected Behavior After Changes

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes