### PR TITLE
Update IIIF Print

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -148,5 +148,5 @@ gem 'order_already'
 
 gem 'hyrax-v2_graph_indexer'
 # rubocop:disable Metrics/LineLength
-gem 'iiif_print', "~> 1.0", git: 'https://github.com/scientist-softserv/iiif_print.git', ref: 'c4121d91c3c03aa5810f5fde08fc874f51010ee9'
+gem 'iiif_print', "~> 1.0", git: 'https://github.com/scientist-softserv/iiif_print.git', ref: 'd6cafaad9a3f66d445403e69b5386692b8c4a60f'
 # rubocop:enable Metrics/LineLength

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,8 +27,8 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: c4121d91c3c03aa5810f5fde08fc874f51010ee9
-  ref: c4121d91c3c03aa5810f5fde08fc874f51010ee9
+  revision: d6cafaad9a3f66d445403e69b5386692b8c4a60f
+  ref: d6cafaad9a3f66d445403e69b5386692b8c4a60f
   specs:
     iiif_print (1.0.0)
       blacklight_iiif_search (~> 1.0)
@@ -37,6 +37,7 @@ GIT
       nokogiri (>= 1.13.2)
       rails (~> 5.0)
       rdf-vocab (~> 3.0)
+      reform-rails (= 0.2.3)
 
 GIT
   remote: https://github.com/tawan/active-elastic-job.git
@@ -280,6 +281,9 @@ GEM
       actionmailer (>= 4.1.0)
       devise (>= 4.0.0)
     diff-lcs (1.4.2)
+    disposable (0.6.3)
+      declarative (>= 0.0.9, < 1.0.0)
+      representable (>= 3.1.1, < 4)
     docile (1.3.2)
     docopt (0.5.0)
     draper (4.0.1)
@@ -906,6 +910,13 @@ GEM
       redis (>= 3.0.4)
     redlock (1.2.1)
       redis (>= 3.0.0, < 5.0)
+    reform (2.6.2)
+      disposable (>= 0.5.0, < 1.0.0)
+      representable (>= 3.1.1, < 4)
+      uber (< 0.2.0)
+    reform-rails (0.2.3)
+      activemodel (>= 5.0)
+      reform (>= 2.3.1, < 3.0.0)
     regexp_parser (1.7.1)
     representable (3.1.1)
       declarative (< 0.1.0)

--- a/app/services/iiif_print/manifest_builder_service_behavior_decorator.rb
+++ b/app/services/iiif_print/manifest_builder_service_behavior_decorator.rb
@@ -3,7 +3,7 @@
 # OVERRIDE IiifPrint v1.0.0 to not render thumbnail files in the UV
 
 IiifPrint::ManifestBuilderServiceBehavior.module_eval do
-  def sanitize_v2(hash:, presenter:, hits:)
+  def sanitize_v2(hash:, presenter:, solr_doc_hits:)
     hash['label'] = sanitize_label(hash['label']) if hash.key?('label')
     hash.delete('description') # removes default description since it's in the metadata fields
     hash['sequences']&.each do |sequence|
@@ -14,7 +14,7 @@ IiifPrint::ManifestBuilderServiceBehavior.module_eval do
 
       sequence['canvases']&.each do |canvas|
         canvas['label'] = sanitize_label(canvas['label'])
-        apply_metadata_to_canvas(canvas: canvas, presenter: presenter, hits: hits)
+        apply_metadata_to_canvas(canvas: canvas, presenter: presenter, solr_doc_hits: solr_doc_hits)
       end
     end
     hash

--- a/spec/services/iiif_print/manifest_builder_service_behavior_decorator_spec.rb
+++ b/spec/services/iiif_print/manifest_builder_service_behavior_decorator_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 # rubocop:disable RSpec/FilePath, Metrics/LineLength
 RSpec.describe IiifPrint::IiifManifestPresenterBehavior do
   let(:presenter) { double(Hyrax::IiifManifestPresenter) }
-  let(:hits) { [double("SolrHit")] }
+  let(:solr_doc_hits) { [double("SolrHit")] }
 
   describe '#sanitize_v2' do
     context 'when thumbnail files are present' do
@@ -163,8 +163,8 @@ RSpec.describe IiifPrint::IiifManifestPresenterBehavior do
       before { allow(service).to receive(:apply_metadata_to_canvas) }
 
       it 'does not include thumbnail files in the returned hash' do
-        expect(service.sanitize_v2(hash: manifest_w_thumbnail_hash, presenter: presenter, hits: hits)['sequences'].first['canvases'].pluck('label')).not_to include("20000230.TN.jpg")
-        expect(service.sanitize_v2(hash: manifest_w_thumbnail_hash, presenter: presenter, hits: hits)['sequences'].first['canvases'].pluck('label')).to include("20000230.OBJ.jpg")
+        expect(service.sanitize_v2(hash: manifest_w_thumbnail_hash, presenter: presenter, solr_doc_hits: solr_doc_hits)['sequences'].first['canvases'].pluck('label')).not_to include("20000230.TN.jpg")
+        expect(service.sanitize_v2(hash: manifest_w_thumbnail_hash, presenter: presenter, solr_doc_hits: solr_doc_hits)['sequences'].first['canvases'].pluck('label')).to include("20000230.OBJ.jpg")
       end
     end
   end


### PR DESCRIPTION
This commit will update the SHA of the IIIF Print gem to bring in the latest changes.  Also, the ManifestBuilderServiceBehaviorDecorator was updated to prevent breaking.

ref: https://github.com/scientist-softserv/iiif_print/commit/d6cafaad9a3f66d445403e69b5386692b8c4a60f, https://github.com/scientist-softserv/iiif_print/commit/3dce3e40baeceefda54c03b9405fc94618cce4a2