### PR TITLE
I395 dates replaced by ActiveTriples::Relations

### DIFF
--- a/app/views/hyrax/journal_articles/_form_metadata.html.erb
+++ b/app/views/hyrax/journal_articles/_form_metadata.html.erb
@@ -18,8 +18,6 @@
           so that the "Part of" label shows "Periodical" instead %>
       <% if (f.object.multiple? term) && term == :part_of %>
         <%= f.input term, label: 'Periodical', as: :multi_value, input_html: { class: 'form-control' }, required: f.object.required?(term) %>
-      <% elsif f.object.multiple? term %>
-        <%= f.input term, as: :multi_value, input_html: { class: 'form-control' }, required: f.object.required?(term) %>
       <% else %>
         <%= render_edit_field_partial(term, f: f) %>
       <% end %>

--- a/app/views/hyrax/journal_articles/_form_metadata.html.erb
+++ b/app/views/hyrax/journal_articles/_form_metadata.html.erb
@@ -21,7 +21,7 @@
       <% elsif f.object.multiple? term %>
         <%= f.input term, as: :multi_value, input_html: { class: 'form-control' }, required: f.object.required?(term) %>
       <% else %>
-        <%= f.input term, required: f.object.required?(term) %>
+        <%= render_edit_field_partial(term, f: f) %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/hyrax/journal_articles/edit_fields/_date_created.html.erb
+++ b/app/views/hyrax/journal_articles/edit_fields/_date_created.html.erb
@@ -1,0 +1,7 @@
+<% # use date picker %>
+
+<% if f.object.class.multiple? key %>
+    <%= f.input key, as: :multi_value, input_html: { data: { provide: 'datepicker', 'date-force-parse': 'false', 'date-autoclose': 'true' } }, required: f.object.required?(key) %>
+<% else %>
+  <%= f.input key, input_html: { value: f.object.model[key].first, data: { provide: 'datepicker', 'date-force-parse': 'false', 'date-autoclose': 'true' } }, required: f.object.required?(key) %>
+<% end %>

--- a/app/views/journal_articles/edit_fields/_date_created.html.erb
+++ b/app/views/journal_articles/edit_fields/_date_created.html.erb
@@ -1,0 +1,7 @@
+<% # use date picker %>
+
+<% if f.object.class.multiple? key %>
+    <%= f.input key, as: :multi_value, input_html: { data: { provide: 'datepicker', 'date-force-parse': 'false', 'date-autoclose': 'true' } }, required: f.object.required?(key) %>
+<% else %>
+  <%= f.input key, input_html: { value: f.object.model[key].first, data: { provide: 'datepicker', 'date-force-parse': 'false', 'date-autoclose': 'true' } }, required: f.object.required?(key) %>
+<% end %>

--- a/app/views/journal_articles/edit_fields/_default.html.temp.erb
+++ b/app/views/journal_articles/edit_fields/_default.html.temp.erb
@@ -1,0 +1,6 @@
+<% # the hyrax version of this file messes singular field display %>
+<% if f.object.class.multiple? key %>
+  <%= f.input key, as: :multi_value, input_html: { class: 'form-control' }, required: f.object.required?(key) %>
+<% else %>
+  <%= f.input key, required: f.object.required?(key), input_html: { value: f.object.model[key].first } %>
+<% end %>

--- a/app/views/records/edit_fields/_default.html.erb
+++ b/app/views/records/edit_fields/_default.html.erb
@@ -1,0 +1,8 @@
+<% # the hyrax version of this file messes singular field display %>
+<% if f.object.class.multiple?(key) %>
+  <%= f.input key, as: :multi_value, input_html: { class: 'form-control' }, required: f.object.required?(key) %>
+<% else %>
+  <% value = f.object.model[key] %>
+  <% value = value.first if value.is_a? ActiveTriples::Relation %>
+  <%= f.input key, required: f.object.required?(key), input_html: { value: value } %>
+<% end %>


### PR DESCRIPTION
# Story

Refs #395  

# Expected Behavior Before Changes
When a user edited a Journal Article and saved it, some fields would change to display ActiveTriple::Relations strings.

# Expected Behavior After Changes
On Edit, the data persists as expected. Date fields should render as dates, for example. 

# Screenshots / Video

<details> 

<summary>

**BEFORE**

</summary>

![image](https://github.com/scientist-softserv/adventist-dl/assets/10081604/190bc4ca-d1c4-4eec-8b04-d9211d98c48a)


</details>

<details> 

<summary>

**AFTER**

</summary>

![image](https://github.com/scientist-softserv/adventist-dl/assets/10081604/9240e1e9-c278-492f-b9d1-8352a842a1b7)

</details>

# Notes

If this does not resolve production/staging data, we may need to reimport those works. 

**TODO**: Client to verify and make a list of ones she notices aren't corrected. 

## ADDITIONAL CONTEXT
ref: https://github.com/scientist-softserv/adventist-dl/pull/398#issuecomment-1542281641