### PR TITLE
🎁 Add "Peer Reviewed?" field faceting

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -118,6 +118,7 @@ class CatalogController < ApplicationController
     # config.add_facet_field solr_name("file_format", :facetable), limit: 5
     # config.add_facet_field solr_name("contributor", :facetable), label: "Contributor", limit: 5
     config.add_facet_field solr_name('member_of_collections', :symbol), limit: 5, label: 'Collections'
+    config.add_facet_field solr_name("refereed", :facetable), limit: 5
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request


### PR DESCRIPTION
This commit will add the "Peer Reviewed?" field to the facets on the catalog search results page.  It will allow for the the ability to filter by "Peer Reviewed?".

- Resolves https://github.com/scientist-softserv/adventist-dl/issues/185

# Story

Refs: #185 

# Expected Behavior Before Changes

Peer Reviewed? was not a faceted field.

# Expected Behavior After Changes

Peer Reviewed? now is a faceted field.

# Screenshots

<details>
<summary>Facet</summary>

<img width="739" alt="image" src="https://github.com/scientist-softserv/adventist-dl/assets/19597776/9c95a16f-ccc4-4960-9b89-85d6441f6957">

</details>

<details>
<summary>Show page</summary>

<img width="1169" alt="image" src="https://github.com/scientist-softserv/adventist-dl/assets/19597776/0bb34383-6a7f-4cd8-816b-b5e9a52e08bb">

</details>

<details>
<summary>Edit form</summary>

<img width="1359" alt="image" src="https://github.com/scientist-softserv/adventist-dl/assets/19597776/1d084b88-c79e-4a96-bc63-f9960fa166b4">

</details>
