### PR TITLE
Fix UV metadata search

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -72,7 +72,8 @@ class CatalogController < ApplicationController
     config.default_solr_params = {
       qt: "search",
       rows: 10,
-      qf: "title_tesim description_tesim creator_tesim keyword_tesim all_text_timv"
+      qf: IiifPrint.config.metadata_fields.keys.map { |attribute| "#{attribute}_tesim" }
+                   .join(' ') << "title_tesim description_tesim all_text_timv"
     }
 
     # Specify which field to use in the tag cloud on the homepage.

--- a/config/initializers/iiif_print.rb
+++ b/config/initializers/iiif_print.rb
@@ -35,6 +35,62 @@ IiifPrint.config do |config|
     page_suffix = "Page #{(page_number.to_i + 1).to_s.rjust(page_padding.to_i, '0')}"
     "#{filename} - #{page_suffix} || #{identifier}"
   }
+
+  config.metadata_fields = {
+    creator: { render_as: :faceted },
+    resource_type: { render_as: :faceted },
+    abstract: {},
+    presented_at: {},
+    location: {},
+    event_date: {},
+    part_of: { render_as: :faceted },
+    editor: {},
+    publisher: { render_as: :faceted },
+    place_of_publication: {},
+    date_published: {},
+    publication_status: {},
+    refereed: {},
+    pagination: {},
+    doi: {},
+    related_url: {},
+    identifier: {},
+    subject: { render_as: :faceted },
+    keyword: { render_as: :faceted },
+    language: { render_as: :faceted },
+    based_near: {},
+    rights_statement: { render_as: :rights_statement },
+    license: { render_as: :license },
+    aark_id: {},
+    date_created: {},
+    department: {},
+    qualification_level: {},
+    qualification_name: {},
+    module_code: {},
+    description: {},
+    source: { render_as: :faceted },
+    volume_number: {},
+    issue_number: {},
+    date_submitted: {},
+    date_accepted: {},
+    date_available: {},
+    remote_url: {},
+    contributor: { render_as: :faceted },
+    output_of: {},
+    date_issued: {},
+    bibliographic_citation: {},
+    alt: {},
+    advisor: {},
+    awarding_institution: {},
+    date_of_award: {},
+    funder: {},
+    isbn: {},
+    extent: {},
+    part: { render_as: :faceted },
+    series: {},
+    edition: {},
+    collection: {}
+  }
+
   # rubocop:enable Metrics/LineLength
 end
 


### PR DESCRIPTION
This commit will fix the UV metadata search by updating the properties
of the config.metadata_fields in iiif_print.rb

Ref#288

![Screenshot 2023-05-17 at 4 10 17 PM](https://github.com/scientist-softserv/adventist-dl/assets/95306716/725842e7-21d4-4631-90ea-7ef1d395ff74)
