### PR TITLE
I421 embed youtube link

### DIFF
--- a/app/assets/stylesheets/viewer.scss
+++ b/app/assets/stylesheets/viewer.scss
@@ -5,9 +5,7 @@
 .viewer {
   height: 100%;
   padding: 10px;
-  iframe {
-    // position: absolute;
-  }
+
 }
 
 #viewer-modal {
@@ -20,4 +18,9 @@
   button.close {
     margin-bottom: 10px;
   }
+}
+
+.video-embed-viewer {
+  aspect-ratio: 16 / 9;
+  width: 100%;
 }

--- a/app/forms/hyrax/conference_item_form.rb
+++ b/app/forms/hyrax/conference_item_form.rb
@@ -5,12 +5,14 @@
 module Hyrax
   class ConferenceItemForm < Hyrax::Forms::WorkForm
     self.model_class = ConferenceItem
+    self.terms += %i[
+      video_embed
+    ]
 
     self.terms -= DogBiscuits.config.base_properties
     self.terms += DogBiscuits.config.conference_item_properties
 
     # Add any local properties here
-    self.terms += []
 
     self.required_fields = DogBiscuits.config.conference_item_properties_required
 

--- a/app/forms/hyrax/dataset_form.rb
+++ b/app/forms/hyrax/dataset_form.rb
@@ -5,12 +5,14 @@
 module Hyrax
   class DatasetForm < Hyrax::Forms::WorkForm
     self.model_class = Dataset
+    self.terms += %i[
+      video_embed
+    ]
 
     self.terms -= DogBiscuits.config.base_properties
     self.terms += DogBiscuits.config.dataset_properties
 
     # Add any local properties here
-    self.terms += []
 
     self.required_fields = DogBiscuits.config.dataset_properties_required
 

--- a/app/forms/hyrax/generic_work_form.rb
+++ b/app/forms/hyrax/generic_work_form.rb
@@ -17,9 +17,7 @@ module Hyrax
       place_of_publication
       remote_url
       resource_type
+      video_embed
     ]
-    def primary_terms
-      super + %i[video_embed]
-    end
   end
 end

--- a/app/forms/hyrax/generic_work_form.rb
+++ b/app/forms/hyrax/generic_work_form.rb
@@ -18,5 +18,8 @@ module Hyrax
       remote_url
       resource_type
     ]
+    def primary_terms
+      super + %i[video_embed]
+    end
   end
 end

--- a/app/forms/hyrax/published_work_form.rb
+++ b/app/forms/hyrax/published_work_form.rb
@@ -5,12 +5,14 @@
 module Hyrax
   class PublishedWorkForm < Hyrax::Forms::WorkForm
     self.model_class = PublishedWork
+    self.terms += %i[
+      video_embed
+    ]
 
     self.terms -= DogBiscuits.config.base_properties
     self.terms += DogBiscuits.config.published_work_properties
 
     # Add any local properties here
-    self.terms += []
 
     self.required_fields = DogBiscuits.config.published_work_properties_required
 

--- a/app/forms/hyrax/thesis_form.rb
+++ b/app/forms/hyrax/thesis_form.rb
@@ -5,12 +5,14 @@
 module Hyrax
   class ThesisForm < Hyrax::Forms::WorkForm
     self.model_class = Thesis
+    self.terms += %i[
+      video_embed
+    ]
 
     self.terms -= DogBiscuits.config.base_properties
     self.terms += DogBiscuits.config.thesis_properties
 
     # Add any local properties here
-    self.terms += []
 
     self.required_fields = DogBiscuits.config.thesis_properties_required
 

--- a/app/models/adventist_metadata.rb
+++ b/app/models/adventist_metadata.rb
@@ -37,11 +37,6 @@ module AdventistMetadata
     property :identifier, predicate: ::RDF::Vocab::DC.identifier
     property :based_near, predicate: ::RDF::Vocab::FOAF.based_near, class_name: Hyrax::ControlledVocabularies::Location
 
-    # This is for the video embed
-    property :video_embed, predicate: ::RDF::URI("https://schema.org/embedUrl"), multiple: false do |index|
-      index.as :stored_searchable
-    end
-
     # Due to the mappings for Bulkrax the "related_url" is not exposed as a field we can "import
     # into".  What do I mean by that?  For importers we map the related_url to "remote_files" then
     # ingest those files.  However, we do also expose a means of assigning a "related_url" via the

--- a/app/models/adventist_metadata.rb
+++ b/app/models/adventist_metadata.rb
@@ -37,6 +37,11 @@ module AdventistMetadata
     property :identifier, predicate: ::RDF::Vocab::DC.identifier
     property :based_near, predicate: ::RDF::Vocab::FOAF.based_near, class_name: Hyrax::ControlledVocabularies::Location
 
+    # This is for the video embed
+    property :video_embed, predicate: ::RDF::URI("https://schema.org/embedUrl"), multiple: false do |index|
+      index.as :stored_searchable
+    end
+
     # Due to the mappings for Bulkrax the "related_url" is not exposed as a field we can "import
     # into".  What do I mean by that?  For importers we map the related_url to "remote_files" then
     # ingest those files.  However, we do also expose a means of assigning a "related_url" via the

--- a/app/models/conference_item.rb
+++ b/app/models/conference_item.rb
@@ -3,6 +3,7 @@
 # Generated via
 #  `rails generate dog_biscuits:work ConferenceItem`
 class ConferenceItem < DogBiscuits::ConferenceItem
+  include VideoEmbedViewer
   include ::Hyrax::WorkBehavior
   include SlugBug
 

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -3,6 +3,7 @@
 # Generated via
 #  `rails generate dog_biscuits:work Dataset`
 class Dataset < DogBiscuits::Dataset
+  include VideoEmbedViewer
   include ::Hyrax::WorkBehavior
   include SlugBug
 

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class GenericWork < ActiveFedora::Base
+  include VideoEmbedViewer
   include ::Hyrax::WorkBehavior
   include DogBiscuits::Abstract
   include DogBiscuits::BibliographicCitation
@@ -20,20 +21,6 @@ class GenericWork < ActiveFedora::Base
   )
 
   validates :title, presence: { message: 'Your work must have a title.' }
-
-  # rubocop:disable Style/RegexpLiteral
-  validates :video_embed,
-            format: {
-              # regex matches only youtube & vimeo urls that are formatted as embed links.
-              with: /(http:\/\/|https:\/\/)(www\.)?(player\.vimeo\.com|youtube\.com\/embed)/,
-              message: "Error: must be a valid YouTube or Vimeo Embed URL."
-            },
-            if: :video_embed?
-  # rubocop:enable Style/RegexpLiteral
-
-  def video_embed?
-    video_embed.present?
-  end
 
   self.indexer = WorkIndexer
   self.human_readable_type = 'Work'

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -21,6 +21,19 @@ class GenericWork < ActiveFedora::Base
 
   validates :title, presence: { message: 'Your work must have a title.' }
 
+  validates :video_embed,
+            format: {
+              # regex matches only youtube & vimeo urls that are formatted as embed links.
+              with: /(http:\/\/|https:\/\/)(www\.)?(player\.vimeo\.com|youtube\.com\/embed)/,
+              message: "Error: must be a valid YouTube or Vimeo Embed URL."
+            },
+            if: :video_embed?
+  # rubocop:enable Style/RegexpLiteral
+
+  def video_embed?
+  video_embed.present?
+  end
+
   self.indexer = WorkIndexer
   self.human_readable_type = 'Work'
 

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -21,6 +21,7 @@ class GenericWork < ActiveFedora::Base
 
   validates :title, presence: { message: 'Your work must have a title.' }
 
+  # rubocop:disable Style/RegexpLiteral
   validates :video_embed,
             format: {
               # regex matches only youtube & vimeo urls that are formatted as embed links.
@@ -31,7 +32,7 @@ class GenericWork < ActiveFedora::Base
   # rubocop:enable Style/RegexpLiteral
 
   def video_embed?
-  video_embed.present?
+    video_embed.present?
   end
 
   self.indexer = WorkIndexer

--- a/app/models/published_work.rb
+++ b/app/models/published_work.rb
@@ -3,6 +3,7 @@
 # Generated via
 #  `rails generate dog_biscuits:work PublishedWork`
 class PublishedWork < DogBiscuits::PublishedWork
+  include VideoEmbedViewer
   include ::Hyrax::WorkBehavior
   include SlugBug
   include DogBiscuits::BibliographicCitation

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -36,6 +36,7 @@ class SolrDocument
   attribute :bibliographic_citation, Solr::String, solr_name('bibliographic_citation')
   attribute :alt, Solr::String, solr_name('alt')
   attribute :file_set_ids, Solr::Array, 'file_set_ids_ssim'
+  attribute :video_embed, Solr::String, 'video_embed_tesim'
 
   def remote_url
     self[Solrizer.solr_name('remote_url')]

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -3,6 +3,7 @@
 # Generated via
 #  `rails generate dog_biscuits:work Thesis`
 class Thesis < DogBiscuits::Thesis
+  include VideoEmbedViewer
   include ::Hyrax::WorkBehavior
   include SlugBug
   include DogBiscuits::BibliographicCitation

--- a/app/models/video_embed_viewer.rb
+++ b/app/models/video_embed_viewer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module VideoEmbedViewer
+  extend ActiveSupport::Concern
+
+  included do
+    # adding video embed option various work types
+    property :video_embed, predicate: ::RDF::URI("https://schema.org/embedUrl"), multiple: false do |index|
+      index.as :stored_searchable
+    end
+
+    # rubocop:disable Style/RegexpLiteral
+    validates :video_embed,
+              format: {
+                # regex matches only youtube & vimeo urls that are formatted as embed links.
+                with: /(http:\/\/|https:\/\/)(www\.)?(player\.vimeo\.com|youtube\.com\/embed)/,
+                message: "Error: must be a valid YouTube or Vimeo Embed URL."
+              },
+              if: :video_embed?
+    # rubocop:enable Style/RegexpLiteral
+
+    def video_embed?
+      video_embed.present?
+    end
+  end
+end

--- a/app/presenters/hyku/work_show_presenter.rb
+++ b/app/presenters/hyku/work_show_presenter.rb
@@ -21,7 +21,15 @@ module Hyku
       isbns&.flatten&.compact
     end
 
+    def video_embed_viewer?
+      extract_video_embed_presence
+    end
+
     private
+
+    def extract_video_embed_presence
+      solr_document[:video_embed_tesim].present?
+    end
 
       def extract_from_identifier(rgx)
         if solr_document['identifier_tesim'].present?

--- a/app/presenters/hyku/work_show_presenter.rb
+++ b/app/presenters/hyku/work_show_presenter.rb
@@ -27,9 +27,9 @@ module Hyku
 
     private
 
-    def extract_video_embed_presence
-      solr_document[:video_embed_tesim].present?
-    end
+      def extract_video_embed_presence
+        solr_document[:video_embed_tesim].present?
+      end
 
       def extract_from_identifier(rgx)
         if solr_document['identifier_tesim'].present?

--- a/app/views/hyrax/base/_video_embed_viewer.html.erb
+++ b/app/views/hyrax/base/_video_embed_viewer.html.erb
@@ -1,0 +1,3 @@
+<div class="col-sm-12">
+  <iframe class='video-embed-viewer' src="<%="#{@presenter.solr_document[:video_embed_tesim].first}"%>" title="Video Player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -15,13 +15,23 @@
       <div class="panel-body">
         <div class="row">
           <%= render 'workflow_actions_widget', presenter: @presenter %>
-          <% if @presenter.universal_viewer? %>
-            <div class="col-sm-12">
-              <%= render 'representative_media', presenter: @presenter, viewer: true %>
-            </div>
-          <% end %>
+          <div class="col-sm-12">
+            <% if @presenter.video_embed_viewer? %>
+              <%= render 'video_embed_viewer', presenter: @presenter %>
+            <% else %>
+              <% if @presenter.universal_viewer? %>
+                <%= render 'representative_media', presenter: @presenter, viewer: true %>
+              <% end %>
+            <% end %>
+          </div>
           <div class="col-sm-5 text-center">
-            <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.universal_viewer? %>
+            <% if @presenter.video_embed_viewer? %>
+            <% else %>
+              <% if @presenter.universal_viewer? %>
+              <% else %>
+                <%= render 'representative_media', presenter: @presenter, viewer: false %>
+              <% end %>
+            <% end %>
             <%= render 'citations', presenter: @presenter %>
             <%= render 'social_media' %>
           </div>

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -66,6 +66,7 @@ if Settings.bulkrax.enabled
         'model' => { from: ['model', 'work_type'] },
         'remote_files' => { from: ['related_url'], split: ';', parsed: true },
         'thumbnail_url' => { from: ['thumbnail_url'], default_thumbnail: true, parsed: true },
+        'video_embed' => { from: ['video_embed'] },
         'refereed' => { from: ['peer_reviewed'] }
     }
     config.field_mappings['Bulkrax::CsvParser'] = {
@@ -100,6 +101,7 @@ if Settings.bulkrax.enabled
         'remote_files' => { from: ['related_url'], split: ';', parsed: true },
         'remote_url' => { from: ['official_url', 'remote_url'], split: ';' },
         'thumbnail_url' => { from: ['thumbnail_url'], default_thumbnail: true, parsed: true },
+        'video_embed' => { from: ['video_embed'] },
         'refereed' => { from: ['peer_reviewed'] }
     }
 

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1124,6 +1124,7 @@ en:
         resource_type: Pre-defined categories to describe the type of content being uploaded, such as &quot;article&quot; or &quot;dataset.&quot;  More than one type may be selected.
         subject: Headings or index terms describing what the work is about; these do need to conform to an existing vocabulary.
         title: A name to aid in identifying a work.
+        video_embed: Youtube or Vimeo iframe embed code to show video embedded in the work page. If you enter an embed link for a video, it must be a properly formatted url beginning with 'http://' or 'https://'. It also needs to contain a valid link to a hosted video that can appear in an iframe. <br /><br /><i>Examples:<br/>https://player.vimeo.com/video/467264493?h=b089de0eab<br/>https://www.youtube.com/embed/Znf73dsFdC8</i>
     labels:
       collection:
         size: Size
@@ -1156,7 +1157,6 @@ en:
         related_url: Related URL
         rights_statement: Rights statement
         title: Title
-        video_embed: "Youtube or Vimeo iframe embed code to show video embedded in the work page. If you enter an embed link for a video, it must be a properly formatted url beginning with 'http://' or 'https://'. It also needs to contain a valid link to a hosted video that can appear in an iframe. <br /><br /><i>Examples:<br/>https://player.vimeo.com/video/467264493?h=b089de0eab<br/>https://www.youtube.com/embed/Znf73dsFdC8</i>"
         visibility_after_embargo: then open it up to
         visibility_after_lease: then restrict it to
         visibility_during_embargo: Restricted to

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1156,6 +1156,7 @@ en:
         related_url: Related URL
         rights_statement: Rights statement
         title: Title
+        video_embed: "Youtube or Vimeo iframe embed code to show video embedded in the work page. If you enter an embed link for a video, it must be a properly formatted url beginning with 'http://' or 'https://'. It also needs to contain a valid link to a hosted video that can appear in an iframe. <br /><br /><i>Examples:<br/>https://player.vimeo.com/video/467264493?h=b089de0eab<br/>https://www.youtube.com/embed/Znf73dsFdC8</i>"
         visibility_after_embargo: then open it up to
         visibility_after_lease: then restrict it to
         visibility_during_embargo: Restricted to


### PR DESCRIPTION
Ref #421 

Prior to these commits:
The Universal Viewer was the only show page media player.

With these commits:
An embedded video player has been created and enabled to play embedded video links on the work show page.

# Screenshots

<details>

![Conference](https://github.com/scientist-softserv/adventist-dl/assets/95306716/45792848-17ad-4ff2-b52d-de9047691590)
![Dataset](https://github.com/scientist-softserv/adventist-dl/assets/95306716/8e0783f9-f51e-41e6-8cae-8fa3639341a1)
![Generic Work](https://github.com/scientist-softserv/adventist-dl/assets/95306716/11bb423f-d3be-4e39-b146-5521c90f79a7)
![Published](https://github.com/scientist-softserv/adventist-dl/assets/95306716/1c32b718-c33e-433c-8539-3a8ac731910b)
![Thesis](https://github.com/scientist-softserv/adventist-dl/assets/95306716/e1acb165-df77-4946-9ed1-44f15ca2e7c8)

</details>
