### PR TITLE
⚙ Upping memory limits

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -5,7 +5,7 @@ resources:
     memory: "4Gi"
     cpu: "1000m"
   limits:
-    memory: "4Gi"
+    memory: "8Gi"
     cpu: "2000m"
 
 livenessProbe:
@@ -181,7 +181,7 @@ worker:
       memory: "4Gi"
       cpu: "1000m"
     limits:
-      memory: "4Gi"
+      memory: "8Gi"
       cpu: "2000m"
   podSecurityContext:
     runAsUser: 1001


### PR DESCRIPTION
This commit will set the limit of memory to be double the request size. We noticed the worker was crashing and this was the recommended fix.
