### PR TITLE
🐛 Switch from get to post for solr URIs

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -68,6 +68,10 @@ class CatalogController < ApplicationController
     config.view.gallery.partials = %i[index_header index]
     config.view.slideshow.partials = [:index]
 
+    # Because too many times on Samvera tech people raise a problem regarding a failed query to SOLR.
+    # Often, it's because they inadvertently exceeded the character limit of a GET request.
+    config.http_method = :post
+
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params
     config.default_solr_params = {
       qt: "search",

--- a/app/services/hyrax/collections/permissions_service_decorator.rb
+++ b/app/services/hyrax/collections/permissions_service_decorator.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# OVERRIDE Hyrax v2.9.5 to use `post` rather than `get`
+
+module Hyrax
+  module Collections
+    module PermissionsServiceDecorator
+      def filter_source(source_type:, ids:)
+        return [] if ids.empty?
+        id_clause = "{!terms f=id}#{ids.join(',')}"
+        query = case source_type
+                when 'admin_set'
+                  "_query_:\"{!raw f=has_model_ssim}AdminSet\""
+                when 'collection'
+                  "_query_:\"{!raw f=has_model_ssim}Collection\""
+                end
+        query += " AND #{id_clause}"
+        ActiveFedora::SolrService.query(query, { fl: 'id', rows: ids.count, method: :post }).map { |hit| hit['id'] }
+      end
+    end
+  end
+end
+
+Hyrax::Collections::PermissionsService.singleton_class.send(:prepend, Hyrax::Collections::PermissionsServiceDecorator)

--- a/app/services/hyrax/collections/permissions_service_decorator.rb
+++ b/app/services/hyrax/collections/permissions_service_decorator.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-# OVERRIDE Hyrax v2.9.5 to use `post` rather than `get`
-
+# OVERRIDE class Hyrax::Collections::PermissionsService from Hyrax v2.9.5
 module Hyrax
   module Collections
     module PermissionsServiceDecorator
+      # OVERRIDE: use `post` rather than `get` to handle larger query sizes
       def filter_source(source_type:, ids:)
         return [] if ids.empty?
         id_clause = "{!terms f=id}#{ids.join(',')}"
@@ -15,7 +15,7 @@ module Hyrax
                   "_query_:\"{!raw f=has_model_ssim}Collection\""
                 end
         query += " AND #{id_clause}"
-        ActiveFedora::SolrService.query(query, { fl: 'id', rows: ids.count, method: :post }).map { |hit| hit['id'] }
+        ActiveFedora::SolrService.query(query, fl: 'id', rows: ids.count, method: :post).map { |hit| hit['id'] }
       end
     end
   end

--- a/lib/active_fedora/solr_service_decorator.rb
+++ b/lib/active_fedora/solr_service_decorator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# OVERRIDE: use post instead of get to allow larger size queries
+module ActiveFedora
+  module SolrServiceDecorator
+    # Get the count of records that match the query
+    # @param [String] query a solr query
+    # @param [Hash] args arguments to pass through to `args' param of SolrService.query (note that :rows will be overwritten to 0)
+    # @return [Integer] number of records matching
+    def count(query, args = {})
+      args = args.merge(rows: 0)
+      SolrService.post(query, args)['response']['numFound'].to_i
+    end
+  end
+end
+
+ActiveFedora::SolrService.singleton_class.send(:prepend, ActiveFedora::SolrServiceDecorator)

--- a/lib/active_fedora/solr_service_decorator.rb
+++ b/lib/active_fedora/solr_service_decorator.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
-# OVERRIDE: use post instead of get to allow larger size queries
+# OVERRIDE: class ActiveFedora::SolrService from Fedora 12.1.1
 module ActiveFedora
   module SolrServiceDecorator
     # Get the count of records that match the query
     # @param [String] query a solr query
-    # @param [Hash] args arguments to pass through to `args' param of SolrService.query (note that :rows will be overwritten to 0)
+    # @param [Hash] args arguments to pass through to `args' param of SolrService.query
+    # (note that :rows will be overwritten to 0)
     # @return [Integer] number of records matching
+    #
+    # OVERRIDE: use `post` rather than `get` to handle larger query sizes
     def count(query, args = {})
       args = args.merge(rows: 0)
       SolrService.post(query, args)['response']['numFound'].to_i


### PR DESCRIPTION
# Story

Additional work may be needed to paginate the collection queries but this provides an initial quick solution.

Refs:
- #445 

# Expected Behavior Before Changes
Dashboard work and collection lists crashed due to various solr errors.

# Expected Behavior After Changes
After creating SDAPI collections from their spreadsheet, work and collection views on the dashboard open correctly.

# Screenshots / Video

<details>
<summary></summary>

![Screenshot 2023-06-12 at 6 53 23 PM](https://github.com/scientist-softserv/adventist-dl/assets/17851674/2f8411b8-cf5d-4fef-89e4-04fbdce4004e)
![Screenshot 2023-06-12 at 6 53 29 PM](https://github.com/scientist-softserv/adventist-dl/assets/17851674/3e9e9b60-aabf-41a4-a32e-9a12c662b133)
</details>

# Notes
