### PR TITLE
🎁 Add highlights and snippets

### DIFF
--- a/app/assets/stylesheets/adl-overrides/adl-overrides.scss
+++ b/app/assets/stylesheets/adl-overrides/adl-overrides.scss
@@ -24,7 +24,7 @@ body.public-facing {
   p {
     color: $darkgrey;
   }
-  
+
   .lh-40 {
     line-height: 40px;
   }
@@ -50,16 +50,16 @@ body.public-facing {
     border: 1px solid $mediumyellow;
     color: $darkyellow;
     outline: 0;
-    &:hover, 
+    &:hover,
     &:focus,
-    &.focus, 
-    &:active, 
-    &.active, 
+    &.focus,
+    &:active,
+    &.active,
     &.active:hover,
     &.active:focus,
     &:active:hover,
-    &:active:focus, 
-    &:active.focus, 
+    &:active:focus,
+    &:active.focus,
     &.active.focus {
       border-color: $darkyellow;
       border: 1px solid $darkyellow;
@@ -81,16 +81,16 @@ body.public-facing {
     letter-spacing: 1px;
     text-transform: uppercase;
     font-size: small;
-    &:hover, 
+    &:hover,
     &:focus,
-    &.focus, 
-    &:active, 
-    &.active, 
+    &.focus,
+    &:active,
+    &.active,
     &.active:hover,
     &.active:focus,
     &:active:hover,
-    &:active:focus, 
-    &:active.focus, 
+    &:active:focus,
+    &:active.focus,
     &.active.focus {
       border-color: $mediumgrey;
       border: 2px solid $mediumgrey;
@@ -326,16 +326,16 @@ body.public-facing {
     &.alert-success {
       background: linear-gradient(#efefef, $white, $white, #efefef);
     }
-    
+
     &.alert-info {
       background: linear-gradient(#dde5ee, #f7f7f7, $white, #f7f7f7, #dde5ee);
     }
-    
+
     &.alert-warning {
       background: linear-gradient(#fff7db, #f7f7f7, $white, #f7f7f7, #fff7db);
     }
   }
-  
+
   .legend {
     color: $black !important;
   }
@@ -387,7 +387,7 @@ body.public-facing {
     background-color: $white;
     border: 0;
   }
-  
+
   .dropdown-btn:hover,
   li.dropdown-item:hover {
     color: $darkyellow;
@@ -406,7 +406,7 @@ body.public-facing {
     background-color: $lightgrey;
     border: 0;
   }
-  
+
   .form-control {
     transition: border ease-in-out 0.2s, box-shadow ease-in-out 0.15s;
     &:focus {
@@ -422,7 +422,7 @@ body.public-facing {
     background-color: $white !important;
     border-radius: 4px !important;
   }
-  
+
   nav.breadcrumb {
     margin-top: 50px;
   }
@@ -431,11 +431,11 @@ body.public-facing {
   .label-success {
     background-color: $mediumyellow;
   }
-  
+
   .label-info {
     background-color: $darkyellow;
   }
-  
+
   .label-primary {
     background-color: $darkyellow;
   }
@@ -469,4 +469,10 @@ body.public-facing {
     width: 30px;
     object-fit: cover;
   }
+}
+
+// for catalog search result snippets
+.highlight {
+  background: yellow;
+  font-weight: 700;
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@
 
 class ApplicationController < ActionController::Base
   include HykuHelper
+  include IiifPrintHelper
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception, prepend: true
@@ -19,7 +20,7 @@ class ApplicationController < ActionController::Base
   include Hyrax::ThemedLayoutController
   with_themed_layout '1_column'
 
-  helper_method :current_account, :admin_host?
+  helper_method :current_account, :admin_host?, :render_ocr_snippets
   before_action :authenticate_if_needed
   before_action :require_active_account!, if: :multitenant?
   before_action :set_account_specific_connections!
@@ -31,6 +32,24 @@ class ApplicationController < ActionController::Base
   end
 
   protected
+
+    # remove this once we've backported to `IIIFPrintHelper` and update IIIF Print
+    def render_ocr_snippets(options = {})
+      snippets = options[:value]
+      # rubocop:disable Rails/OutputSafety
+      snippets_content = [ActionController::Base.helpers.content_tag('div',
+                                                                     "... #{snippets.first} ...".html_safe,
+                                                                     class: 'ocr_snippet first_snippet')]
+      # rubocop:enable Rails/OutputSafety
+      if snippets.length > 1
+        snippets_content << render(partial: 'catalog/snippets_more',
+                                   locals: { snippets: snippets.drop(1),
+                                             options: options })
+      end
+      # rubocop:disable Rails/OutputSafety
+      snippets_content.join("\n").html_safe
+      # rubocop:enable Rails/OutputSafety
+    end
 
     def is_hidden
       current_account.persisted? && !current_account.is_public?

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -36,7 +36,8 @@ class CatalogController < ApplicationController
 
   configure_blacklight do |config|
     # IiifPrint index fields
-    config.add_index_field 'all_text_timv', highlight: true, helper_method: :render_ocr_snippets
+    config.add_index_field 'all_text_timv'
+    config.add_index_field 'file_set_text_tsimv', label: "Item contents", highlight: true, helper_method: :render_ocr_snippets
 
     # configuration for Blacklight IIIF Content Search
     config.iiif_search = {
@@ -77,7 +78,12 @@ class CatalogController < ApplicationController
       qt: "search",
       rows: 10,
       qf: IiifPrint.config.metadata_fields.keys.map { |attribute| "#{attribute}_tesim" }
-                   .join(' ') << "title_tesim description_tesim all_text_timv"
+                   .join(' ') << "title_tesim description_tesim all_text_timv file_set_text_tsimv",
+      "hl": true,
+      "hl.simple.pre": "<span class='highlight'>",
+      "hl.simple.post": "</span>",
+      "hl.snippets": 30,
+      "hl.fragsize": 100
     }
 
     # Specify which field to use in the tag cloud on the homepage.


### PR DESCRIPTION
This commit will add highlights and snippets for the catalog search. Currently we are putting all changes in ADL while the Rodeo/SpaceStone work is in progress, but ideally we want to backport all the changes back to IIIF Print.

Co-authored-by: LaRita Robinson <laritakr@gmail.com>

- Ref: https://github.com/scientist-softserv/adventist-dl/issues/414

# Expected Behavior Before Changes

When doing a text search, snippets don't show up.

# Expected Behavior After Changes

When doing a text search, snippets will now show up and the searched term gets highlighted.

# Screenshots / Video

<img width="1284" alt="image" src="https://github.com/scientist-softserv/adventist-dl/assets/19597776/066b870f-ecd7-4810-bdb0-d78fb9f0578b">

# Notes

This will require a reindex of parent works.