### PR TITLE
:gift: add parent child relationship config to adl bulkrax's csv parser

### DIFF
--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -105,6 +105,11 @@ if Settings.bulkrax.enabled
         'refereed' => { from: ['peer_reviewed'] }
     }
 
+    config.field_mappings['Bulkrax::CsvParser'].merge!(
+      'parents' => { from: ['parents'], split: /\s*[;|]\s*/, related_parents_field_mapping: true },
+      'children' => { from: ['children'], split: /\s*[;|]\s*/, related_children_field_mapping: true }
+    )
+
     # Lambda to set the default field mapping
     config.default_field_mapping = lambda do |field|
       return if field.blank?


### PR DESCRIPTION
# Story

We were planning to establish relationships in production between records and collections, by uploading a csv. However, the parent/child bulkrax configuration was not set up. 

Refs:

- #446

# Expected Behavior After Changes
When I upload the following sample CSV, it should create collections and establish relationships per the parents column. 

[archive-collection-relation.csv](https://github.com/scientist-softserv/adventist-dl/files/11738743/archive-collection-relation.csv)

# Screenshots / Video

![Screenshot 2023-06-13 at 12-53-36 Collections](https://github.com/scientist-softserv/adventist-dl/assets/10081604/92d12e13-1ae1-48d4-bd64-c2ea4fe66569)
