### PR TITLE
i420 pdf txt from uv

### DIFF
--- a/app/indexers/hyrax/file_set_indexer.rb
+++ b/app/indexers/hyrax/file_set_indexer.rb
@@ -72,7 +72,7 @@ module Hyrax
         # The regex should reflect what is set in the `config/initializers/iiif_print.rb`,
         # `config.unique_child_title_generator_function`.
         page_number = parent_title[/Page \d+/]
-        return parent_title unless page_number
+        return object.label unless page_number
 
         work_title = parent.member_of.first&.title&.first
         return parent_title unless work_title

--- a/app/services/iiif_print/manifest_builder_service_behavior_decorator.rb
+++ b/app/services/iiif_print/manifest_builder_service_behavior_decorator.rb
@@ -2,7 +2,35 @@
 
 # OVERRIDE IiifPrint v1.0.0 to not render thumbnail files in the UV
 
+# rubocop:disable Metrics/BlockLength
 IiifPrint::ManifestBuilderServiceBehavior.module_eval do
+  def build_manifest(presenter:)
+    manifest = manifest_factory.new(presenter).to_h
+    hash = JSON.parse(manifest.to_json)
+    parent_and_child_solr_hits = parent_and_child_solr_hits(presenter) if @child_works.present?
+    hash = send("sanitize_v#{@version}", hash: hash, presenter: presenter, solr_doc_hits: parent_and_child_solr_hits)
+    if @child_works.present? && IiifPrint.config.sort_iiif_manifest_canvases_by
+      send("sort_canvases_v#{@version}",
+           hash: hash,
+           sort_field: IiifPrint.config.sort_iiif_manifest_canvases_by)
+    end
+    hash['rendering'] = rendering(presenter: presenter)
+    hash
+  end
+
+  def rendering(presenter:)
+    file_set_presenters = presenter.file_set_presenters.reject { |fsp| fsp.mime_type.include?('image') }
+
+    file_set_presenters.map do |fsp|
+      {
+        # Yes, we are using `#send` because `#hostname` is a private method, though I think it's okay here
+        "@id": Hyrax::Engine.routes.url_helpers.download_url(fsp.id, host: presenter.send(:hostname)),
+        "label": fsp.label,
+        "format": fsp.mime_type
+      }
+    end
+  end
+
   def sanitize_v2(hash:, presenter:, solr_doc_hits:)
     hash['label'] = sanitize_label(hash['label']) if hash.key?('label')
     hash.delete('description') # removes default description since it's in the metadata fields
@@ -24,3 +52,4 @@ IiifPrint::ManifestBuilderServiceBehavior.module_eval do
     CGI.unescapeHTML(sanitize_value(label))
   end
 end
+# rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
[🐛 Fix thumbnails showing up in uv](https://github.com/scientist-softserv/adventist-dl/commit/ff4ee852d6b2e7ab990e1dfda8469d7ad519b112) 

This PR accidentally broke the logic to hide the thumbnail in UV.
https://github.com/scientist-softserv/adventist-dl/pull/364

This commit fixes it.

---

[🎁 Add download non-image files from UV](https://github.com/scientist-softserv/adventist-dl/commit/f7368f10818b8b558c0ea87e8f9208631e0d1b66) 

This commit adds the ability to download non-image files from UV.  It
takes a look at all the FileSetPresenters and determines if their
mime-types and rejects all images so theoretically for ADL, we should be
left with the PDF and TXT files.

- Ref: https://github.com/scientist-softserv/adventist-dl/issues/420

# Expected Behavior Before Changes

The Universal Viewer download options for the file currently viewed and nothing else.

# Expected Behavior After Changes

The UV download options have been expanded to include the non-image file sets

# Screenshots / Video

<img width="546" alt="image" src="https://github.com/scientist-softserv/adventist-dl/assets/19597776/da18116d-15ad-4ca6-97c1-ffccb5928cf2">

# Note
⚠️ The bug fix commit does require a reindex, not too urgent though ⚠️