### PR TITLE
[i95] - :gear: set staging and prod env vars for iiif serverless

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -91,6 +91,8 @@ extraEnvVars: &envVars
     value: "5432"
   - name: DATABASE_USER
     value: postgres
+  - name: EXTERNAL_IIIF_URL
+    value: https://d3pg70bdc74ala.cloudfront.net/iiif/2
   - name: FCREPO_BASE_PATH
     value: /adventist-production
   - name: FCREPO_HOST

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -78,6 +78,8 @@ extraEnvVars: &envVars
     value: adventist
   - name: DATABASE_USER
     value: postgres
+  - name: EXTERNAL_IIIF_URL
+    value: https://d3pg70bdc74ala.cloudfront.net/iiif/2
   - name: FCREPO_BASE_PATH
     value: /adventist
   - name: FCREPO_HOST


### PR DESCRIPTION
# Story

This PR sets the cloudfront url so that images in the UV could be served by aws instead. 

Refs: 

- https://github.com/scientist-softserv/adventist-dl/issues/95

# Expected Behavior After Changes

- [ ] IIIF Server should serve up assets for **UV**

# Screenshots / Video

TBD

<details>
<summary></summary>

</details>

# Notes
