### PR TITLE
🎁 Add persistent highlighting to UV

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,17 +27,17 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: 8fdf56e151b5adb7e6aab1cd29d39b74554ed48a
+  revision: 2c1bd2b4d985d44aba7c89de8b6477f4397fe250
   branch: main
   specs:
     iiif_print (1.0.0)
       blacklight_iiif_search (~> 1.0)
+      derivative-rodeo (~> 0.3)
       dry-monads (~> 1.4.0)
-      hyrax (>= 2.5, < 4.0)
+      hyrax (>= 2.5, < 4)
       nokogiri (>= 1.13.2)
       rails (~> 5.0)
       rdf-vocab (~> 3.0)
-      reform-rails (= 0.2.3)
 
 GIT
   remote: https://github.com/tawan/active-elastic-job.git
@@ -267,6 +267,15 @@ GEM
     deep_merge (1.2.1)
     deprecation (1.1.0)
       activesupport
+    derivative-rodeo (0.4.0)
+      activesupport (>= 5)
+      aws-sdk-s3
+      aws-sdk-sqs
+      httparty
+      marcel
+      mime-types
+      mini_magick
+      nokogiri
     devise (4.7.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -281,9 +290,6 @@ GEM
       actionmailer (>= 4.1.0)
       devise (>= 4.0.0)
     diff-lcs (1.4.2)
-    disposable (0.6.3)
-      declarative (>= 0.0.9, < 1.0.0)
-      representable (>= 3.1.1, < 4)
     docile (1.3.2)
     docopt (0.5.0)
     draper (4.0.1)
@@ -910,13 +916,6 @@ GEM
       redis (>= 3.0.4)
     redlock (1.2.1)
       redis (>= 3.0.0, < 5.0)
-    reform (2.6.2)
-      disposable (>= 0.5.0, < 1.0.0)
-      representable (>= 3.1.1, < 4)
-      uber (< 0.2.0)
-    reform-rails (0.2.3)
-      activemodel (>= 5.0)
-      reform (>= 2.3.1, < 3.0.0)
     regexp_parser (1.7.1)
     representable (3.1.1)
       declarative (< 0.1.0)

--- a/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
+++ b/app/views/hyrax/base/iiif_viewers/_universal_viewer.html.erb
@@ -1,7 +1,0 @@
-<div class="viewer-wrapper">
-  <iframe
-    src="<%= universal_viewer_base_url %>#?manifest=<%= main_app.polymorphic_url [main_app, :manifest, presenter], { locale: nil } %>&config=<%= universal_viewer_config_url %>" 
-    allowfullscreen="true" 
-    frameborder="0" 
-  ></iframe>
-</div>

--- a/config/uv/uv.html
+++ b/config/uv/uv.html
@@ -53,6 +53,7 @@
                 rotation: Number(urlDataProvider.get('r', 0)),
                 xywh: urlDataProvider.get('xywh', ''),
                 embedded: true,
+                highlight: urlDataProvider.get('q'),
                 locales: formattedLocales
             }, urlDataProvider);
         }, false);


### PR DESCRIPTION
# Story

This commit will add the feature of persisting the search from the catalog to the UV.  This will make it better for the user so they don't have to search the same term again.

Ref:
  - https://github.com/scientist-softserv/adventist-dl/issues/470

# Expected Behavior Before Changes

A catalog search did not persist from the catalog to the UV.

# Expected Behavior After Changes

A catalog search now persists to from the catalog to the UV.

# Screenshots / Video

![adl-470](https://github.com/scientist-softserv/adventist-dl/assets/19597776/6e82a1b1-2dee-42ce-8711-ede6d050127d)

# Notes

In the Screen cap, my UV reloads, for some reason it's only happening when I record my screen.