### PR TITLE
🐛 Lock IiifPrint to no-rodeo branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -147,4 +147,4 @@ gem 'dog_biscuits', git: 'https://github.com/samvera-labs/dog_biscuits.git'
 gem 'order_already'
 
 gem 'hyrax-v2_graph_indexer'
-gem 'iiif_print', "~> 1.0", git: 'https://github.com/scientist-softserv/iiif_print.git', branch: 'main'
+gem 'iiif_print', "~> 1.0", git: 'https://github.com/scientist-softserv/iiif_print.git', branch: 'no-rodeo'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,17 +27,17 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: 2c1bd2b4d985d44aba7c89de8b6477f4397fe250
-  branch: main
+  revision: d44ea621b0751d11f054d4ae30b994ea5454c591
+  branch: no-rodeo
   specs:
     iiif_print (1.0.0)
       blacklight_iiif_search (~> 1.0)
-      derivative-rodeo (~> 0.3)
       dry-monads (~> 1.4.0)
-      hyrax (>= 2.5, < 4)
+      hyrax (>= 2.5, < 4.0)
       nokogiri (>= 1.13.2)
       rails (~> 5.0)
       rdf-vocab (~> 3.0)
+      reform-rails (= 0.2.3)
 
 GIT
   remote: https://github.com/tawan/active-elastic-job.git
@@ -267,15 +267,6 @@ GEM
     deep_merge (1.2.1)
     deprecation (1.1.0)
       activesupport
-    derivative-rodeo (0.4.0)
-      activesupport (>= 5)
-      aws-sdk-s3
-      aws-sdk-sqs
-      httparty
-      marcel
-      mime-types
-      mini_magick
-      nokogiri
     devise (4.7.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -290,6 +281,9 @@ GEM
       actionmailer (>= 4.1.0)
       devise (>= 4.0.0)
     diff-lcs (1.4.2)
+    disposable (0.6.3)
+      declarative (>= 0.0.9, < 1.0.0)
+      representable (>= 3.1.1, < 4)
     docile (1.3.2)
     docopt (0.5.0)
     draper (4.0.1)
@@ -916,6 +910,13 @@ GEM
       redis (>= 3.0.4)
     redlock (1.2.1)
       redis (>= 3.0.0, < 5.0)
+    reform (2.6.2)
+      disposable (>= 0.5.0, < 1.0.0)
+      representable (>= 3.1.1, < 4)
+      uber (< 0.2.0)
+    reform-rails (0.2.3)
+      activemodel (>= 5.0)
+      reform (>= 2.3.1, < 3.0.0)
     regexp_parser (1.7.1)
     representable (3.1.1)
       declarative (< 0.1.0)


### PR DESCRIPTION
# Story

The derivative rodeo work in IiifPrint broke the PDF splitting feature. Locking to a non-rodeo branch until the work is thoroughly tested.

Refs: https://github.com/scientist-softserv/adventist-dl/pull/471

# Expected Behavior Before Changes

# Expected Behavior After Changes

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes
Needed for testing #470 