### PR TITLE
🐛 Move render_ocr_snippets method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: d44ea621b0751d11f054d4ae30b994ea5454c591
+  revision: 9f20467a6ff1f14872087f1e1dddda0f9fea91fd
   branch: no-rodeo
   specs:
     iiif_print (1.0.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,6 @@
 
 class ApplicationController < ActionController::Base
   include HykuHelper
-  include IiifPrintHelper
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception, prepend: true
@@ -20,7 +19,7 @@ class ApplicationController < ActionController::Base
   include Hyrax::ThemedLayoutController
   with_themed_layout '1_column'
 
-  helper_method :current_account, :admin_host?, :render_ocr_snippets
+  helper_method :current_account, :admin_host?
   before_action :authenticate_if_needed
   before_action :require_active_account!, if: :multitenant?
   before_action :set_account_specific_connections!
@@ -32,24 +31,6 @@ class ApplicationController < ActionController::Base
   end
 
   protected
-
-    # remove this once we've backported to `IIIFPrintHelper` and update IIIF Print
-    def render_ocr_snippets(options = {})
-      snippets = options[:value]
-      # rubocop:disable Rails/OutputSafety
-      snippets_content = [ActionController::Base.helpers.content_tag('div',
-                                                                     "... #{snippets.first} ...".html_safe,
-                                                                     class: 'ocr_snippet first_snippet')]
-      # rubocop:enable Rails/OutputSafety
-      if snippets.length > 1
-        snippets_content << render(partial: 'catalog/snippets_more',
-                                   locals: { snippets: snippets.drop(1),
-                                             options: options })
-      end
-      # rubocop:disable Rails/OutputSafety
-      snippets_content.join("\n").html_safe
-      # rubocop:enable Rails/OutputSafety
-    end
 
     def is_hidden
       current_account.persisted? && !current_account.is_public?

--- a/app/helpers/iiif_print_helper.rb
+++ b/app/helpers/iiif_print_helper.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module IiifPrintHelper
+  include IiifPrint::IiifPrintHelperBehavior
+end


### PR DESCRIPTION
# Story
Method render_ocr_snippets was causing AbstractController::DoubleRenderError during random situations, due to including the IiifPrintHelper in ApplicationController.

This pull request moves it into a helper module which is injected by the install generator, [which matches how it was done in LV](https://github.com/scientist-softserv/louisville-hyku/blob/b672d2a3213aaee84c082eb8083d8ad70733036b/app/helpers/newspaper_works_helper.rb#L3) & NNP.

Ref #469 & https://github.com/scientist-softserv/iiif_print/pull/254

- Update IiifPrint to use a branch that:
    - does not include derivative rodeo, which broke PDF splitting
    - moves render_ocr_snippets method to an appropriate helpers
 
- Remove definition from application controller.
- Add iiif_print_helper to pull in behavior.

# Expected Behavior Before Changes
The app randomly throws AbstractController::DoubleRenderError when viewing the catalog results page.
# Expected Behavior After Changes
The catalog results page which was previously erroring resolves successfully.
# Screenshots / Video

<details>
<summary></summary>

![Screenshot 2023-06-29 at 7 10 48 PM](https://github.com/scientist-softserv/adventist-dl/assets/17851674/f81dfa04-07d6-475b-beb9-400860809986)
</details>

# Notes
