### PR TITLE
:gear: [i76] add qa tenant to dev environment

### DIFF
--- a/ops/dev-deploy.tmpl.yaml
+++ b/ops/dev-deploy.tmpl.yaml
@@ -40,6 +40,9 @@ extraVolumeMounts: &volMounts
 ingress:
   enabled: true
   hosts:
+    - host: qa.s2.adventistdigitallibrary.org
+      paths:
+        - path: /
     - host: s2.adventistdigitallibrary.org
       paths:
         - path: /


### PR DESCRIPTION
# Story

If a tenant is configured and deployed, the user should be able to create a new tenant by that name. 

Test: qa tenant has been added to dev-deploy.tmpl.yaml

Refs:

- https://github.com/scientist-softserv/adventist-dl/issues/71

# Expected Behavior Before Changes

Creating a tenant would eventually lead to errors. Visiting the tenant's url would crash.

![image](https://github.com/scientist-softserv/adventist-dl/assets/10081604/03eaf512-84f0-4438-b8d7-0b3832fcbdf7)


# Expected Behavior After Changes

Per Rob, we should be able to add the new tenant to the ingress section of the deploy.tmlp.yaml files. THEN the user should be able to successfully create a tenant by that same name. 

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes
