### PR TITLE
🐛 Update IiifPrint and fix PDF splitting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -145,5 +145,5 @@ gem 'blacklight_range_limit', '6.5.0'
 gem 'dog_biscuits', git: 'https://github.com/samvera-labs/dog_biscuits.git'
 
 gem 'hyrax-v2_graph_indexer', git: 'https://github.com/scientist-softserv/hyrax-v2_graph_indexer', branch: 'main'
-gem 'iiif_print', git: 'https://github.com/scientist-softserv/iiif_print.git', branch: 'no-rodeo'
+gem 'iiif_print', git: 'https://github.com/scientist-softserv/iiif_print.git', branch: 'main'
 gem 'order_already'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: 23529a76bef9c90d8ccecd61a8a26c421e0a4ce8
+  revision: fe85c47c1ba8ba7fa0aae14104b86f98a8b581e4
   branch: main
   specs:
     iiif_print (1.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,13 +36,14 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: eb4f238db71698099f02cbb7c38f84213eca7a66
-  branch: no-rodeo
+  revision: 23529a76bef9c90d8ccecd61a8a26c421e0a4ce8
+  branch: main
   specs:
     iiif_print (1.0.0)
       blacklight_iiif_search (~> 1.0)
+      derivative-rodeo (~> 0.3)
       dry-monads (~> 1.4.0)
-      hyrax (>= 2.5, < 4.0)
+      hyrax (>= 2.5, < 4)
       nokogiri (>= 1.13.2)
       rails (~> 5.0)
       rdf-vocab (~> 3.0)
@@ -275,6 +276,15 @@ GEM
     deep_merge (1.2.1)
     deprecation (1.1.0)
       activesupport
+    derivative-rodeo (0.4.0)
+      activesupport (>= 5)
+      aws-sdk-s3
+      aws-sdk-sqs
+      httparty
+      marcel
+      mime-types
+      mini_magick
+      nokogiri
     devise (4.7.2)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)

--- a/lib/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter.rb
+++ b/lib/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter.rb
@@ -22,7 +22,7 @@ module IiifPrint
                     **args)
         return [] if suffixes.any? { |suffix| path.downcase.end_with?(suffix) }
 
-        splitter.call(path, args)
+        splitter.call(path, **args)
       end
     end
   end

--- a/lib/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter.rb
+++ b/lib/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter.rb
@@ -16,13 +16,14 @@ module IiifPrint
       # @note I am adding a {.new} method to a module to mimic the instantiation of a class.
       #
       # @see https://github.com/scientist-softserv/iiif_print/blob/a23706453f23e0f54c9d50bbf0ddf9311d82a0b9/lib/iiif_print/jobs/child_works_from_pdf_job.rb#L39-L63
-      # rubocop:disable Metrics/LineLength
-      def self.new(path, *args, splitter: PagesToJpgsSplitter, suffixes: CreateDerivativesJobDecorator::NON_ARCHIVAL_PDF_SUFFIXES)
+      def self.call(path,
+                    splitter: PagesToJpgsSplitter,
+                    suffixes: CreateDerivativesJobDecorator::NON_ARCHIVAL_PDF_SUFFIXES,
+                    **args)
         return [] if suffixes.any? { |suffix| path.downcase.end_with?(suffix) }
 
-        splitter.new(path, *args)
+        splitter.call(path, args)
       end
-      # rubocop:enable Metrics/LineLength
     end
   end
 end

--- a/spec/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter_spec.rb
+++ b/spec/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter_spec.rb
@@ -3,10 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe IiifPrint::SplitPdfs::AdventistPagesToJpgsSplitter do
-  describe '.new' do
-    subject { described_class.new(path, suffixes: ["spec.rb"], splitter: splitter) }
-
-    let(:splitter) { Class.new { def initialize(path); end } }
+  describe '.call' do
+    subject { described_class.call(path, suffixes: ["spec.rb"], file_set: :file_set) }
 
     context 'when given path ends in the given suffix' do
       let(:path) { __FILE__ }
@@ -17,7 +15,9 @@ RSpec.describe IiifPrint::SplitPdfs::AdventistPagesToJpgsSplitter do
     context 'when given path does not end in the suffix' do
       let(:path) { "#{__FILE__}.hello.rb" }
 
-      it { is_expected.to be_a(splitter) }
+      before { allow(IiifPrint::SplitPdfs::PagesToJpgsSplitter).to receive(:call).and_return(:mocked_split) }
+
+      it { is_expected.to be(:mocked_split) }
     end
   end
 end


### PR DESCRIPTION
# Story

Ref: https://github.com/scientist-softserv/adventist-dl/issues/483

- Updates IiifPrint to include fixes to Derivative Rodeo refactors and bug fixes
  - https://github.com/scientist-softserv/iiif_print/pull/256
  - https://github.com/scientist-softserv/iiif_print/pull/257

- Fixes incompatibilities in the custom Adventist PDF splitter.

# Expected Behavior Before Changes

IiifPrint job to split PDFs did not get called.

# Expected Behavior After Changes

Gemfile includes DerivativeRodeo.
PDFs split correctly into child works.

# Screenshots / Video

<details>
<summary></summary>

![Screenshot 2023-07-05 at 4 29 08 PM](https://github.com/scientist-softserv/adventist-dl/assets/17851674/91c736bd-b4e2-4f36-8e20-9e3c5e45e767)

</details>

# Notes
Move ticket to complete following SoftServe QA.