### PR TITLE
🐛 Fix OCR search count

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,12 +36,12 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: fe85c47c1ba8ba7fa0aae14104b86f98a8b581e4
+  revision: fbe418a98bcdce590fc37401f216876fd4c33ec4
   branch: main
   specs:
     iiif_print (1.0.0)
       blacklight_iiif_search (~> 1.0)
-      derivative-rodeo (~> 0.3)
+      derivative-rodeo (~> 0.4)
       dry-monads (~> 1.4.0)
       hyrax (>= 2.5, < 4)
       nokogiri (>= 1.13.2)


### PR DESCRIPTION
[🐛 Fix OCR search count](https://github.com/scientist-softserv/adventist-dl/commit/ffb530f327073f90a6832c8e8d8373c60210917e) 

This commit updates the SHA for IIIF Print to bring in the fix for
duplicating the same search coordinates.  This should fix the OCR search
count for all future works created.  Previous works would need to be
reimported to generate a the new JSON coordinates.

Ref:
  - https://github.com/scientist-softserv/adventist-dl/issues/477
  - https://github.com/scientist-softserv/iiif_print/commit/18831d8ca1bf1f9423732bcf64836ea043a093df

# Story

Word search counts sometimes don't match because coordinates are being duplicated.

# Expected Behavior Before Changes

Word counts are sometimes off.

# Expected Behavior After Changes

Word counts should be accurate.

# Screenshots / Video

<details>
<summary>Before</summary>

<img width="1150" alt="image" src="https://github.com/scientist-softserv/iiif_print/assets/19597776/1ab20642-a568-4a1f-bfaf-cce2124d0150">

</details>

<details>
<summary>After</summary>

<img width="1149" alt="image" src="https://github.com/scientist-softserv/iiif_print/assets/19597776/836ddba8-f161-4543-a59e-6f5fbf97bed8">

</details>
