### PR TITLE
🐛 OCR count correction

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: fbe418a98bcdce590fc37401f216876fd4c33ec4
+  revision: b61644c3e2c5efe8d52148bdd1b0ceb01d5a370e
   branch: main
   specs:
     iiif_print (1.0.0)
@@ -276,7 +276,7 @@ GEM
     deep_merge (1.2.1)
     deprecation (1.1.0)
       activesupport
-    derivative-rodeo (0.4.0)
+    derivative-rodeo (0.4.2)
       activesupport (>= 5)
       aws-sdk-s3
       aws-sdk-sqs

--- a/app/indexers/work_indexer.rb
+++ b/app/indexers/work_indexer.rb
@@ -41,7 +41,7 @@ class WorkIndexer < Hyrax::WorkIndexer
   end
 
   def all_text(object:)
-    text = IiifPrint.config.all_text_generator_function.call(object: object) || ''
+    text = IiifPrint::Data::WorkDerivatives.data(from: object, of_type: 'txt') || ''
     return text if text.empty?
 
     text.tr("\n", ' ').squeeze(' ')

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -7,8 +7,11 @@
     <% index_fields(document).each do |field_name, field| -%>
       <% if should_render_index_field? document, field %>
           <div class="search-index-metadata-group metadata-<%= field_name %>">
+            <% field_value = doc_presenter.field_value field_name %>
+            <%# Don't show the snippets field if it's empty %>
+            <% next if field_value.blank? %>
             <dt><%= render_index_field_label document, field: field_name %></dt>
-            <dd><%= doc_presenter.field_value field_name %></dd>
+            <dd><%= field_value %></dd>
           </div>
       <% end %>
     <% end %>


### PR DESCRIPTION
This commit will bring in a fix from IIIF Print that will compensate for the count being off due to using snippets.  The OCR text is indexed on the FileSets of each work typically, but in order to get the snippets working, all of the OCR need to also be indexed onto the parent work. This will double the count effectively of everything because it's found on the parent work and also on one of the FileSets.

Also in this commit, it was noted that the parent work started to index the JSON coordinates and not the text itself.  This will be fixed with this update as well.

Lastly, there was a change in IIIF Print that enabled host applications to not display the snippet field if there are no snippets.  This will bring that in as well as leverage that functionality.

Ref:
  - https://github.com/scientist-softserv/adventist-dl/issues/477

# Screenshots / Video

<details><summary>Word Count Before</summary>

<img width="1166" alt="image" src="https://github.com/scientist-softserv/iiif_print/assets/19597776/e3bd799b-c560-41b7-9aae-cadfbed398b5">

</details>

<details><summary>Word Count After</summary>

<img width="1169" alt="image" src="https://github.com/scientist-softserv/iiif_print/assets/19597776/eea5c99f-4093-457d-af23-9d37e74aa70a">

</details>

<details>
<summary>Snippet Before</summary>

<img width="983" alt="image" src="https://github.com/scientist-softserv/iiif_print/assets/19597776/ecadd4a8-0010-4158-8a1c-19ceadb15cad">

</details>

<details>
<summary>Snippet After</summary>

<img width="973" alt="image" src="https://github.com/scientist-softserv/iiif_print/assets/19597776/33fe6bc3-1c2c-40f8-ad67-7dc08e7c9ac1">

</details>

# Notes

We should do a reindex to get all the text onto the snippets and not the JSON coordinates.