### PR TITLE
🎁 Default Skip Thumbnails for OAI Feed

### DIFF
--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -6,6 +6,15 @@ module Bulkrax
     # add any special processing here, for example to reset a metadata property
     # to add a custom property from outside of the import data
     def add_local
+      # Because of the DerivativeRodeo and SpaceStone, we may already have the appropriate thumbnail
+      # ready to attach to the file_sets.  If we proceed with using the thumbnail_url, we end up
+      # attaching that thumbnail as it's own file_set.  Which is likely non-desirous behavior.
+      #
+      # TODO: What is the impact of changing this assumption?
+      if parser.parser_fields['skip_thumbnail_url'] == "1"
+        parsed_metadata.delete('thumbnail_url')
+      end
+
       true
     end
   end

--- a/app/views/bulkrax/importers/_oai_adventist_fields.html.erb
+++ b/app/views/bulkrax/importers/_oai_adventist_fields.html.erb
@@ -18,6 +18,8 @@
 
   <%= fi.input :offset, as: :string, hint: "Start importing after the offset number of records.", input_html: { value: importer.parser_fields['offset'].to_i } %>
 
+  <%= fi.input :skip_thumbnail_url, as: :boolean, hint: "When checked, skip the thumbnail_url found in the feed.  If not checked, we'll still generate a thumbnail.", input_html: { checked: importer.parser_fields.key?('skip_thumbnail_url') ? importer.parser_fields['skip_thumbnail_url'] == "1" : true } %>
+
   <% rights_statements = Hyrax.config.rights_statement_service_class.new %>
   <%= fi.input :rights_statement,
         collection: rights_statements.select_active_options,


### PR DESCRIPTION
**Context:**

We're incorporating the derivative rodeo into the ingest process.  This is first intended to be used by the OAI importer.

The situation is as follows: In the OAI feed there are URLs for both the digital objects and a thumbnail.

Due to prior constraints of ingest, we had to add the thumbnail as a FileSet to the work.  However, with the derivative rodeo, we can look in S3 for an existing thumbnail (that was generated via SpaceStone) and assign that thumbnail to the digital object(s)'s file set.

In other words, we can avoid adding the thumbnail file set (and running all the derivatives on that file set as well).

However, this may conflict with some work done in GitLab I62 (as detailed in commit 433b66a8d95f49bd40335b5483621bb4e4a41227).

**Discussion:**

Prior to adding this change when the derivative service was working on the TN.jpg file (the thumbnail_url that comes with the OAI feed), it was raising a `ArgumentError' error “invalid byte sequence in UTF-8` exception.

What was happening is that the derivative rodeo was wrongly assuming that the TN.jpg was a HOCR file.  It was reading the contents of the file and asking if it was XML.  And that raised the exception.

As mentioned in [this comment][1], "the underlying problem remains." Namely the Derivate Rodeo service in IIIF print needs to better handle second order derivatives (e.g. generate a HOCR file).

**Question:**

- Is this the right approach?
- What is the problem we were solving in @433b66a8d95f49bd40335b5483621bb4e4a41227
- What is the context of I62?

I believe this is best resolved in a pairing/mobbing session.  However, I put this forward for conversation.

**Related to:**

- https://github.com/scientist-softserv/derivative_rodeo/issues/56

[1]:https://github.com/scientist-softserv/derivative_rodeo/issues/56#issuecomment-1634891451
