### PR TITLE
⚙️ Configure PDFs to split into JPG pages

### DIFF
--- a/config/initializers/iiif_print.rb
+++ b/config/initializers/iiif_print.rb
@@ -99,3 +99,5 @@ IiifPrint.config do |config|
 end
 
 require "iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter"
+
+DerivativeRodeo::Generators::PdfSplitGenerator.output_extension = 'jpg'


### PR DESCRIPTION
Based on the findings of the following issue, we are want to continue to split pages into JPGs.

- https://github.com/scientist-softserv/adventist-dl/issues/379

The desire for JPGs for split images is demonstrated in:

- https://github.com/scientist-softserv/adventist-dl/commit/6dd0d7711d60ee4cb9eae9edd65444256fef81cc

**Note:** This changes is preliminary work for when we switch over to using the DerivativeRodeo to split PDFs.  The change will not impact how the original IiifPrint PDF splitting behaves.  (There is work to switch from the original splitting mechanism to the [DerivativeRodeoSplitter][1], but that is still a work in progress).

Related to:

- https://github.com/scientist-softserv/derivative_rodeo/issues/56
- https://github.com/scientist-softserv/adventist-dl/issues/500
- https://github.com/scientist-softserv/space_stone-serverless/pull/36

[1]:https://github.com/scientist-softserv/iiif_print/blob/3938eb0e2f2aa239d6ce52d2d4c597d1146f9651/lib/iiif_print/split_pdfs/derivative_rodeo_splitter.rb

 