### PR TITLE
🐛 Adding monkey patch for ActiveFedora dirty optimizations

### DIFF
--- a/config/initializers/active_fedora_override.rb
+++ b/config/initializers/active_fedora_override.rb
@@ -1,0 +1,11 @@
+# Based on https://github.com/samvera/hyrax/issues/4581#issuecomment-843085122
+
+# Monkey-patch to short circuit ActiveModel::Dirty which attempts to load the whole master files ordered list when calling nodes_will_change!
+# This leads to a stack level too deep exception when attempting to delete a master file from a media object on the manage files step.
+# See https://github.com/samvera/active_fedora/pull/1312/commits/7c8bbbefdacefd655a2ca653f5950c991e1dc999#diff-28356c4daa0d55cbaf97e4269869f510R100-R103
+ActiveFedora::Aggregation::ListSource.class_eval do
+  def attribute_will_change!(attr)
+    return super unless attr == 'nodes'
+    attributes_changed_by_setter[:nodes] = true
+  end
+end


### PR DESCRIPTION
This is a bit of a stretch, based on other testing.  But the included code comment may be relevant.

Without this change I've consistently encounter the following observed behavior:

```gherkin
Given an Bulkrax imported work with child works (e.g. pages split from a PDF)
And I eradicate the imported work and child works
When I re-build (e.g. Bulkrax::Entry#build) the import entry
Then I do not see the attached files nor child works
```

With this change I've consistently encountered the following observed behavior:

```gherkin
Given an Bulkrax imported work with child works (e.g. pages split from a PDF)
And I eradicate the imported work and child works
When I re-build (e.g. Bulkrax::Entry#build) the import entry
Then I will see the work, child works, and derivatives, in the UI
```

**Context**

This is copied from
https://github.com/scientist-softserv/derivative_rodeo/issues/56#issuecomment-1651881982 to highlight the process.

> Starting from a fresh Hyku tenant.  When I import a work, files are associated with that work.  When I eradicate the work and children then reimport the work, then no files show in the UI.
>
> One observation in the code is that the child works and file sets have an `is_child` true but their `is_child_of` is empty.  Which leverages `ordered_by_ids`.
>
> Order of Operations
>
> -   Ensure I have a clean Fedora and SOLR
>     -   `docker compose down -v` works
> -   Check out the main branch
>     -   `git checkout main`
> -   Build and bring up the image
>     -   `docker compose up --force-recreate --build`
> -   Create the new tenant
>     -   Login to hyku.test and create "adventist" tenant
> -   Stop the docker environment
>     -   `docker compose stop`
> -   Set the correct branch and conditions
>     -   This is a mix of stash and different branches.
>     -   Branch `updating-to-test-the-rodeo` incorporates skipping the thumbnails
>     -   Branch `without-slug-bug` is setup to ignore the slug features of Adventist; it is based on `updating-to-test-the-rodeo`
>     -   Git Stash I'm referencing iiif\_print and derivative\_rodeo in `vendor/gems`; my stashed Gemfile and lock reflect this.
>     -   Note: I have bumped the relationship job interval from 10 minutes to 1 minute
>     -   In the `config/initializers/iiif_print.rb` I have add the following two lines at the bottom:
>         -   `# DerivativeRodeo::Generators::PdfSplitGenerator.output_extension = 'jpg'`
>         -   `DerivativeRodeo.config.logger = Logger.new(Rails.root.join("dr.log").to_s, level: Logger::DEBUG)`
>     -   The above two lines use the TIFF for splitting (the format we used in the initial SpaceStone test) and setting the DerivativeRodeo logger means we send the very chatty information from the rodeo to a durable and separate location.  This is helpful for reviewing to see how and what is being used.
> -   Bring up the images without starting services
>     -   I don't want to auto-start the Rails server nor Good Job because we need to clean up two rotten jobs
> -   Bash into Worker and Delete All Jobs
>     -   There should be two jobs the Embargo and Lease job.
>     -   In Rails console ru `GoodJob::Job.destroy_all`
> -   Start the Rails server and good jobs
>     -   Bash into web and run `bundle exec puma -v -b tcp://0.0.0.0:3000`
>     -   Bash into worker
>         -   export the following ENV variables
>             -   `AWS_ACCESS_KEY_ID`
>             -   `AWS_SECRET_ACCESS_KEY`
>             -   `AWS_REGION`
>             -   `AWS_S3_BUCKET`
>     -   Run `bundle exec good_job start`
> -   Create an importer for the adventist tenant
>     -   Using the OAI Parser
>     -   With URL of <http://oai.adventistdigitallibrary.org/OAI-script>
>     -   metadataPrefix of "oai\_adl"
>     -   set of "adl:other"
> -   This import should take somewhere between 5 and 10 minutes
> -   Find one of the following AARK\_ID import entries: 20121816 (3 page PDF) or 20121862 (1 page PDF)
>     -   Make note of the Bulkrax::Entry ID of the work, hereto referred to as `entry_id`
> -   VERIFY WORK STEP: Verify in the UI that the work has at least 3 items: the ARCHIVAL PDF, RAW.txt, and one image per page of the PDF.
> -   Assuming that is the case, shell into the web console and start the rails console and run the following:
>     -   `switch!('adventist')`
>     -   `entry = Bulkrax::Entry.find(entry_id)` # NOTE `entry_id`
>     -   `GoodJob::Job.where(finished_at: nil).where(GoodJob::Job.arel_table['created_at'].lteq(DateTime.current)).joins_advisory_locks.where(pg_locks: { locktype: nil }).destroy_all`
>     -   `entry.factory.find&.child_works&.map {|cw| cw.destroy(eradicate: true) }`
>        - This may output a =ActiveTriples::ParentStrategy::UnmutableParentError= message; if so run again
>     -   `entry.factory.find&.destroy(eradicate: true)`
>        - This may output a =ActiveTriples::ParentStrategy::UnmutableParentError= message; if so I don't believe running it again will matter.
>     -   `entry.build`
> -   Then repeat the VERIFY WORK STEP; you'll likely want to use the importer entries page for the `entry_id`
>
> If we do not have all of the same items as in the VERIFY WORK STEP then we continue to have a deep seeded bug; and may need to change something in the code and repeat some aspect of the checklist.  Perhaps going all the way back to the first step.
>
> What I have observed is that the parent work (e.g. the object associated with `entry.factory.find`) has the correct associations assigned.
>
> `IiifPrint::LineageService.descendent_member_ids_for(work)` returns file\_set and work ids that represent the items in the UI.  However, any of those ids when reified to an ActiveFedora object as `child` and then we call `IiifPrint::LineageService.ancestor_ids_for(child)`, we get an empty array.  We should get an array that is `[work.id]`
>
> Digging deeper, each of the child works has `is_child` of `true` but their `ordered_by_ids` is an empty array.
>
> My current conjecture is one of the following is :
>
> -   The [SlugBug overrides](https://github.com/scientist-softserv/adventist-dl/blob/main/app/models/concerns/slug_bug.rb) are problematic either alone or in relation to IIIF Print
>     -   We can look at <https://github.com/scientist-softserv/adventist-dl/blob/main/config/initializers/slug_override.rb#L58-L69> to see how we amend the retrieval of `ordered_by_ids`
> -   We are missing the often copied `config/initializers/active_fedora_override.rb` in which we apply some changes to `ActiveFedora::Aggregation::ListSource.attribute_will_change!`
>     -   essi
>     -   louisville-hyku
>     -   palni-palci
>     -   nnp
> -   IIIF Print has some other underlying issue with relationships

Related to:

- https://github.com/scientist-softserv/derivative_rodeo/issues/56
- https://github.com/scientist-softserv/nnp/commit/dc970b910bd29918f8d5dc420ffd33f940053e0c
- https://github.com/scientist-softserv/palni-palci/commit/687f3613503ed5fef1a26759d7386adcebd44387
- https://github.com/scientist-softserv/louisville-hyku/commit/8bdead060b494ada90e7b6fdbd5147667ca0f0d6

**NOTE:** We may want to add this to UTK.
