### PR TITLE
Adding the Rodeo without configuring to use the Rodeo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -145,7 +145,7 @@ gem 'blacklight_range_limit', '6.5.0'
 gem 'dog_biscuits', git: 'https://github.com/samvera-labs/dog_biscuits.git'
 
 gem 'hyrax-v2_graph_indexer', git: 'https://github.com/scientist-softserv/hyrax-v2_graph_indexer', branch: 'main'
-# rubcop:disable Metrics/LineLength
+# rubocop:disable Metrics/LineLength
 gem 'iiif_print', git: 'https://github.com/scientist-softserv/iiif_print.git', ref: '9e7837ce4bd08bf8fff9126455d0e0e2602f6018'
-# rubcop:enable Metrics/LineLength
+# rubocop:enable Metrics/LineLength
 gem 'order_already'

--- a/Gemfile
+++ b/Gemfile
@@ -145,5 +145,5 @@ gem 'blacklight_range_limit', '6.5.0'
 gem 'dog_biscuits', git: 'https://github.com/samvera-labs/dog_biscuits.git'
 
 gem 'hyrax-v2_graph_indexer', git: 'https://github.com/scientist-softserv/hyrax-v2_graph_indexer', branch: 'main'
-gem 'iiif_print', git: 'https://github.com/scientist-softserv/iiif_print.git', branch: 'main'
+gem 'iiif_print', git: 'https://github.com/scientist-softserv/iiif_print.git', ref: '9e7837ce4bd08bf8fff9126455d0e0e2602f6018'
 gem 'order_already'

--- a/Gemfile
+++ b/Gemfile
@@ -145,5 +145,7 @@ gem 'blacklight_range_limit', '6.5.0'
 gem 'dog_biscuits', git: 'https://github.com/samvera-labs/dog_biscuits.git'
 
 gem 'hyrax-v2_graph_indexer', git: 'https://github.com/scientist-softserv/hyrax-v2_graph_indexer', branch: 'main'
+# rubcop:disable Metrics/LineLength
 gem 'iiif_print', git: 'https://github.com/scientist-softserv/iiif_print.git', ref: '9e7837ce4bd08bf8fff9126455d0e0e2602f6018'
+# rubcop:enable Metrics/LineLength
 gem 'order_already'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,12 +36,12 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: b61644c3e2c5efe8d52148bdd1b0ceb01d5a370e
-  branch: main
+  revision: 9e7837ce4bd08bf8fff9126455d0e0e2602f6018
+  ref: 9e7837ce4bd08bf8fff9126455d0e0e2602f6018
   specs:
     iiif_print (1.0.0)
       blacklight_iiif_search (~> 1.0)
-      derivative-rodeo (~> 0.4)
+      derivative-rodeo (~> 0.5)
       dry-monads (~> 1.4.0)
       hyrax (>= 2.5, < 4)
       nokogiri (>= 1.13.2)
@@ -276,7 +276,7 @@ GEM
     deep_merge (1.2.1)
     deprecation (1.1.0)
       activesupport
-    derivative-rodeo (0.4.2)
+    derivative-rodeo (0.5.0)
       activesupport (>= 5)
       aws-sdk-s3
       aws-sdk-sqs

--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -11,9 +11,7 @@ module Bulkrax
       # attaching that thumbnail as it's own file_set.  Which is likely non-desirous behavior.
       #
       # TODO: What is the impact of changing this assumption?
-      if parser.parser_fields['skip_thumbnail_url'] == "1"
-        parsed_metadata.delete('thumbnail_url')
-      end
+      parser.parser_fields['skip_thumbnail_url'] == "1" && parsed_metadata.delete('thumbnail_url')
 
       true
     end

--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -6,6 +6,15 @@ module Bulkrax
     # add any special processing here, for example to reset a metadata property
     # to add a custom property from outside of the import data
     def add_local
+      # Because of the DerivativeRodeo and SpaceStone, we may already have the appropriate thumbnail
+      # ready to attach to the file_sets.  If we proceed with using the thumbnail_url, we end up
+      # attaching that thumbnail as it's own file_set.  Which is likely non-desirous behavior.
+      #
+      # TODO: What is the impact of changing this assumption?
+      if parser.parser_fields['skip_thumbnail_url'] == "1"
+        parsed_metadata.delete('thumbnail_url')
+      end
+
       true
     end
   end

--- a/app/views/bulkrax/importers/_oai_adventist_fields.html.erb
+++ b/app/views/bulkrax/importers/_oai_adventist_fields.html.erb
@@ -18,6 +18,8 @@
 
   <%= fi.input :offset, as: :string, hint: "Start importing after the offset number of records.", input_html: { value: importer.parser_fields['offset'].to_i } %>
 
+  <%= fi.input :skip_thumbnail_url, as: :boolean, hint: "When checked, skip the thumbnail_url found in the feed.  If not checked, we'll still generate a thumbnail.", input_html: { checked: importer.parser_fields.key?('skip_thumbnail_url') ? importer.parser_fields['skip_thumbnail_url'] == "1" : true } %>
+
   <% rights_statements = Hyrax.config.rights_statement_service_class.new %>
   <%= fi.input :rights_statement,
         collection: rights_statements.select_active_options,

--- a/config/application.rb
+++ b/config/application.rb
@@ -70,9 +70,16 @@ module Hyku
       # enabling text extraction from plain text files.
       Hyrax::DerivativeService.services = [
         Adventist::TextFileTextExtractionService,
-        IiifPrint::DerivativeRodeoService,
-        Hyrax::FileSetDerivativesService
-      ]
+        IiifPrint::PluggableDerivativeService]
+
+      # When you are ready to use the derivative rodeo instead of the pluggable uncomment the
+      # following and comment out the preceding Hyrax::DerivativeService.service
+      #
+      # Hyrax::DerivativeService.services = [
+      #   Adventist::TextFileTextExtractionService,
+      #   IiifPrint::DerivativeRodeoService,
+      #   Hyrax::FileSetDerivativesService]
+
       DerivativeRodeo::Generators::HocrGenerator.additional_tessearct_options = "-l eng_best"
 
       # Allows us to use decorator files

--- a/config/application.rb
+++ b/config/application.rb
@@ -65,12 +65,15 @@ module Hyku
       # authenticity token errors.
       Hyrax::Admin::AppearancesController.form_class = AppearanceForm
 
-      # See https://gitlab.com/notch8/adventist-dl/-/issues/147
-      #
       # By default plain text files are not processed for text extraction.  In adding
       # Adventist::TextFileTextExtractionService to the beginning of the services array we are
       # enabling text extraction from plain text files.
-      Hyrax::DerivativeService.services.unshift(Adventist::TextFileTextExtractionService)
+      Hyrax::DerivativeService.services = [
+        Adventist::TextFileTextExtractionService,
+        IiifPrint::DerivativeRodeoService,
+        Hyrax::FileSetDerivativesService
+      ]
+      DerivativeRodeo::Generators::HocrGenerator.additional_tessearct_options = "-l eng_best"
 
       # Allows us to use decorator files
       Dir.glob(File.join(File.dirname(__FILE__), "../app/**/*_decorator*.rb")).sort.each do |c|

--- a/config/initializers/iiif_print.rb
+++ b/config/initializers/iiif_print.rb
@@ -100,4 +100,28 @@ end
 
 require "iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter"
 
+# Adventist wants to reduce storage size of their split pages; JPGs are a reasonable storage size
+# compared to TIFFs
 DerivativeRodeo::Generators::PdfSplitGenerator.output_extension = 'jpg'
+
+####################################################################################################
+# The DerivativeRodeo is responsible for finding, moving, and/or generating files from various
+# places.  I have found it invaluable to have a segmented logger for that particular set of
+# functions.  Imagine importing 25 works from an OAI feed, and all of the chatter you'll see.  Now
+# try to find the DerivativeRodeo specific calls, as it:
+#
+# - Checks if the file exists at the output location
+# - Checks if the file exists at the preprocessed location
+# - Copies the preprocessed file to the output location
+# - Generates the file to the output location based on the input uri (by copying that locally)
+# - Sniffs out if a PDF has been split into constituent pages
+#
+# Uncomment the `DerivativeRodeo.config.logger` line, spin up They Might Be Giants's "Doctor Worm"
+# and start tailing good ol' "Dr. Log".  It is what helped me see, in detail, what was happening
+# with all of these bits flying hither and yon.
+#
+# NOTE: By default `DerivativeRodeo.config.logger` will be automatically set to `Rails.logger` when
+# `Rails.logger` is defined.
+####################################################################################################
+
+# DerivativeRodeo.config.logger = Logger.new(Rails.root.join("dr.log").to_s, level: Logger::DEBUG)

--- a/lib/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter.rb
+++ b/lib/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter.rb
@@ -11,13 +11,13 @@ module IiifPrint
       # @param splitter [IiifPrint::SplitPdfs::BaseSplitter] (for dependency injection)
       # @param suffix [String] (for dependency injection)
       #
-      # @return [#to_a] when we are going to skip splitting, return an empty array; otherwise return
+      # @return [Enumerable] when we are going to skip splitting, return an empty array; otherwise return
       #         an instance of {IiifPrint::SplitPdfs::AdventistPagesToJpgsSplitter}.
       # @note I am adding a {.new} method to a module to mimic the instantiation of a class.
       #
       # @see https://github.com/scientist-softserv/iiif_print/blob/a23706453f23e0f54c9d50bbf0ddf9311d82a0b9/lib/iiif_print/jobs/child_works_from_pdf_job.rb#L39-L63
       def self.call(path,
-                    splitter: PagesToJpgsSplitter,
+                    splitter: DerivativeRodeoSplitter,
                     suffixes: CreateDerivativesJobDecorator::NON_ARCHIVAL_PDF_SUFFIXES,
                     **args)
         return [] if suffixes.any? { |suffix| path.downcase.end_with?(suffix) }

--- a/lib/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter.rb
+++ b/lib/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter.rb
@@ -17,7 +17,8 @@ module IiifPrint
       #
       # @see https://github.com/scientist-softserv/iiif_print/blob/a23706453f23e0f54c9d50bbf0ddf9311d82a0b9/lib/iiif_print/jobs/child_works_from_pdf_job.rb#L39-L63
       def self.call(path,
-                    splitter: DerivativeRodeoSplitter,
+                    # splitter: DerivativeRodeoSplitter,
+                    splitter: PagesToJpgsSplitter,
                     suffixes: CreateDerivativesJobDecorator::NON_ARCHIVAL_PDF_SUFFIXES,
                     **args)
         return [] if suffixes.any? { |suffix| path.downcase.end_with?(suffix) }

--- a/spec/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter_spec.rb
+++ b/spec/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe IiifPrint::SplitPdfs::AdventistPagesToJpgsSplitter do
     context 'when given path does not end in the suffix' do
       let(:path) { "#{__FILE__}.hello.rb" }
 
+      # before { allow(IiifPrint::SplitPdfs::DerivativeRodeoSplitter).to receive(:call).and_return(:mocked_split) }
       before { allow(IiifPrint::SplitPdfs::PagesToJpgsSplitter).to receive(:call).and_return(:mocked_split) }
 
       it { is_expected.to be(:mocked_split) }

--- a/spec/search_builders/adv_search_builder_spec.rb
+++ b/spec/search_builders/adv_search_builder_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe AdvSearchBuilder do
         exclude_models
         highlight_search_params
         show_parents_only
+        include_allinson_flex_fields
       ]
     end
 

--- a/spec/services/adventist/text_file_text_extraction_service_spec.rb
+++ b/spec/services/adventist/text_file_text_extraction_service_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Adventist::TextFileTextExtractionService do
       expect(Hyrax::DerivativeService.services).to(
         match_array(
           [Adventist::TextFileTextExtractionService,
-           IiifPrint::PluggableDerivativeService,
+           IiifPrint::DerivativeRodeoService,
            Hyrax::FileSetDerivativesService]
         )
       )

--- a/spec/services/adventist/text_file_text_extraction_service_spec.rb
+++ b/spec/services/adventist/text_file_text_extraction_service_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe Adventist::TextFileTextExtractionService do
       expect(Hyrax::DerivativeService.services).to(
         match_array(
           [Adventist::TextFileTextExtractionService,
-           IiifPrint::PluggableDerivativeService])
+           IiifPrint::PluggableDerivativeService]
+        )
       )
       # expect(Hyrax::DerivativeService.services).to(
       #   match_array(

--- a/spec/services/adventist/text_file_text_extraction_service_spec.rb
+++ b/spec/services/adventist/text_file_text_extraction_service_spec.rb
@@ -25,10 +25,15 @@ RSpec.describe Adventist::TextFileTextExtractionService do
       expect(Hyrax::DerivativeService.services).to(
         match_array(
           [Adventist::TextFileTextExtractionService,
-           IiifPrint::DerivativeRodeoService,
-           Hyrax::FileSetDerivativesService]
-        )
+           IiifPrint::PluggableDerivativeService])
       )
+      # expect(Hyrax::DerivativeService.services).to(
+      #   match_array(
+      #     [Adventist::TextFileTextExtractionService,
+      #      IiifPrint::DerivativeRodeoService,
+      #      Hyrax::FileSetDerivativesService]
+      #   )
+      # )
     end
   end
 


### PR DESCRIPTION
## 🎁 WIP Configuring DerivativeRodeo splitter

6e6a782910b589150e14c1e67b661e0c99a99427

Related to:

- https://github.com/scientist-softserv/derivative_rodeo/issues/56

## 🎁 Default Skip Thumbnails for OAI Feed

e663bcb2128331cccc9c20d6b917ce115a931e4a

**Context:**

We're incorporating the derivative rodeo into the ingest process.  This
is first intended to be used by the OAI importer.

The situation is as follows: In the OAI feed there are URLs for both the
digital objects and a thumbnail.

Due to prior constraints of ingest, we had to add the thumbnail as a
FileSet to the work.  However, with the derivative rodeo, we can
look in S3 for an existing thumbnail (that was generated via SpaceStone)
and assign that thumbnail to the digital object(s)'s file set.

In other words, we can avoid adding the thumbnail file set (and running
all the derivatives on that file set as well).

However, this may conflict with some work done in GitLab I62 (as
detailed in commit @433b66a8d95f49bd40335b5483621bb4e4a41227).

**Discussion:**

Prior to adding this change when the derivative service was working on
the TN.jpg file (the thumbnail_url that comes with the OAI feed), it was
raising a `ArgumentError' error “invalid byte sequence in UTF-8`
exception.

What was happening is that the derivative rodeo was wrongly assuming
that the TN.jpg was a HOCR file.  It was reading the contents of the
file and asking if it was XML.  And that raised the exception.

As mentioned in [this comment][1], "the underlying problem remains."
Namely the Derivate Rodeo service in IIIF print needs to better handle
second order derivatives (e.g. generate a HOCR file).

**Question:**

- Is this the right approach?
- What is the problem we were solving in @433b66a8d95f49bd40335b5483621bb4e4a41227
- What is the context of I62?

I believe this is best resolved in a pairing/mobbing session.  However,
I put this forward for conversation.

**Related to:**

- https://github.com/scientist-softserv/derivative_rodeo/issues/56

[1]:https://github.com/scientist-softserv/derivative_rodeo/issues/56#issuecomment-1634891451

## 📚 Adding documentation about configuring rodeo logger

b4e6113b4200736cb9e39060059d39a9a04b2c84

Yes, we could have a DerivativeRodeo initializer...but we leverage the
Rodeo by way of IiifPrint.  So this makes sense as to the place to
configure these things.

In addition, I figured I'd share one of the things I did to help in the
debugging of the DerivativeRodeo integration.  Which has me thinking
that perhaps we should look at doing this with the IiifPrint gem.  After
all, debugging that is also challenging.

Related to:

- https://github.com/scientist-softserv/derivative_rodeo/issues/56

## 🎁 Incorporating v0.5.0 of Derivative Rodeo

6eeced0d9382961db4ef5162a730dd72d6a4e36e

These changes reflect work done in verifying the following ticket:

- https://github.com/scientist-softserv/derivative_rodeo/issues/56

## 🚧 Revert using DerivativeRodeo

95ddce8895057f4834502aa45f7ad3be51c9c2af

This commit reverts using the Derivative Rodeo for PDF splitting and
derivative generation.  It is also breadcrumbs for how to restore those
functions.  We revert from the Derivative Rodeo to the already
established IIIF Print pluggable derivatives derived from the Newspaper
works gem.

The reason to revert is that this branch includes several changes that
went into local testing of the DerivativeRodeo; and I want to capture
those wins and merge in an already long-running branch, to reduce the
chance of further branch drift.

For reference, local testing of the DerivativeRodeo has worked both with
and without having SpaceStone data for both PDF splitting and generating
derivatives (e.g.  thumbnails, word coordinates, alto files, and plain
text).  However, I had only done localized testing and I believe more
testing is warranted; namely how does the full text search work.

To consider is how we will:

- Test on staging with the Rodeo but not have it in play for Production

But that is an exercise for the person undoing this commit :)

Related to:

- https://github.com/scientist-softserv/derivative_rodeo/issues/56
- https://github.com/scientist-softserv/adventist-dl/issues/500
