### PR TITLE
Revert code: This enables the Derivative Rodeo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -145,7 +145,7 @@ gem 'blacklight_range_limit', '6.5.0'
 gem 'dog_biscuits', git: 'https://github.com/samvera-labs/dog_biscuits.git'
 
 gem 'hyrax-v2_graph_indexer', git: 'https://github.com/scientist-softserv/hyrax-v2_graph_indexer', branch: 'main'
-# rubocop:disable Metrics/LineLength
+# rubcop:disable Metrics/LineLength
 gem 'iiif_print', git: 'https://github.com/scientist-softserv/iiif_print.git', ref: '9e7837ce4bd08bf8fff9126455d0e0e2602f6018'
-# rubocop:enable Metrics/LineLength
+# rubcop:enable Metrics/LineLength
 gem 'order_already'

--- a/Gemfile
+++ b/Gemfile
@@ -145,7 +145,5 @@ gem 'blacklight_range_limit', '6.5.0'
 gem 'dog_biscuits', git: 'https://github.com/samvera-labs/dog_biscuits.git'
 
 gem 'hyrax-v2_graph_indexer', git: 'https://github.com/scientist-softserv/hyrax-v2_graph_indexer', branch: 'main'
-# rubcop:disable Metrics/LineLength
 gem 'iiif_print', git: 'https://github.com/scientist-softserv/iiif_print.git', ref: '9e7837ce4bd08bf8fff9126455d0e0e2602f6018'
-# rubcop:enable Metrics/LineLength
 gem 'order_already'

--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -11,7 +11,9 @@ module Bulkrax
       # attaching that thumbnail as it's own file_set.  Which is likely non-desirous behavior.
       #
       # TODO: What is the impact of changing this assumption?
-      parser.parser_fields['skip_thumbnail_url'] == "1" && parsed_metadata.delete('thumbnail_url')
+      if parser.parser_fields['skip_thumbnail_url'] == "1"
+        parsed_metadata.delete('thumbnail_url')
+      end
 
       true
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -70,16 +70,9 @@ module Hyku
       # enabling text extraction from plain text files.
       Hyrax::DerivativeService.services = [
         Adventist::TextFileTextExtractionService,
-        IiifPrint::PluggableDerivativeService]
-
-      # When you are ready to use the derivative rodeo instead of the pluggable uncomment the
-      # following and comment out the preceding Hyrax::DerivativeService.service
-      #
-      # Hyrax::DerivativeService.services = [
-      #   Adventist::TextFileTextExtractionService,
-      #   IiifPrint::DerivativeRodeoService,
-      #   Hyrax::FileSetDerivativesService]
-
+        IiifPrint::DerivativeRodeoService,
+        Hyrax::FileSetDerivativesService
+      ]
       DerivativeRodeo::Generators::HocrGenerator.additional_tessearct_options = "-l eng_best"
 
       # Allows us to use decorator files

--- a/lib/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter.rb
+++ b/lib/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter.rb
@@ -17,8 +17,7 @@ module IiifPrint
       #
       # @see https://github.com/scientist-softserv/iiif_print/blob/a23706453f23e0f54c9d50bbf0ddf9311d82a0b9/lib/iiif_print/jobs/child_works_from_pdf_job.rb#L39-L63
       def self.call(path,
-                    # splitter: DerivativeRodeoSplitter,
-                    splitter: PagesToJpgsSplitter,
+                    splitter: DerivativeRodeoSplitter,
                     suffixes: CreateDerivativesJobDecorator::NON_ARCHIVAL_PDF_SUFFIXES,
                     **args)
         return [] if suffixes.any? { |suffix| path.downcase.end_with?(suffix) }

--- a/spec/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter_spec.rb
+++ b/spec/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe IiifPrint::SplitPdfs::AdventistPagesToJpgsSplitter do
     context 'when given path does not end in the suffix' do
       let(:path) { "#{__FILE__}.hello.rb" }
 
-      # before { allow(IiifPrint::SplitPdfs::DerivativeRodeoSplitter).to receive(:call).and_return(:mocked_split) }
       before { allow(IiifPrint::SplitPdfs::PagesToJpgsSplitter).to receive(:call).and_return(:mocked_split) }
 
       it { is_expected.to be(:mocked_split) }

--- a/spec/search_builders/adv_search_builder_spec.rb
+++ b/spec/search_builders/adv_search_builder_spec.rb
@@ -48,7 +48,6 @@ RSpec.describe AdvSearchBuilder do
         exclude_models
         highlight_search_params
         show_parents_only
-        include_allinson_flex_fields
       ]
     end
 

--- a/spec/services/adventist/text_file_text_extraction_service_spec.rb
+++ b/spec/services/adventist/text_file_text_extraction_service_spec.rb
@@ -25,15 +25,10 @@ RSpec.describe Adventist::TextFileTextExtractionService do
       expect(Hyrax::DerivativeService.services).to(
         match_array(
           [Adventist::TextFileTextExtractionService,
-           IiifPrint::PluggableDerivativeService])
+           IiifPrint::DerivativeRodeoService,
+           Hyrax::FileSetDerivativesService]
+        )
       )
-      # expect(Hyrax::DerivativeService.services).to(
-      #   match_array(
-      #     [Adventist::TextFileTextExtractionService,
-      #      IiifPrint::DerivativeRodeoService,
-      #      Hyrax::FileSetDerivativesService]
-      #   )
-      # )
     end
   end
 

--- a/spec/services/adventist/text_file_text_extraction_service_spec.rb
+++ b/spec/services/adventist/text_file_text_extraction_service_spec.rb
@@ -25,8 +25,7 @@ RSpec.describe Adventist::TextFileTextExtractionService do
       expect(Hyrax::DerivativeService.services).to(
         match_array(
           [Adventist::TextFileTextExtractionService,
-           IiifPrint::PluggableDerivativeService]
-        )
+           IiifPrint::PluggableDerivativeService])
       )
       # expect(Hyrax::DerivativeService.services).to(
       #   match_array(


### PR DESCRIPTION
## Revert "💄 Appeasing rubocop and not rubcop"

1edf246281417b8061ecc24582714d7034a1db77

This reverts commit a820df080f25c36781e112fb2f1ccb5171e43e97.

## Revert "🐛 Appeasing Rubocop and Fixing Spec"

32b8f5f2a53da05e06abf68d4edba9ef9a3f4322

This reverts commit efc315a99cbaca8c9a3c81307fbdefdf3454197d.

## Revert "🚧 Revert using DerivativeRodeo"

3429bed84c6a6e0dbe55b21eec079258b79f7171

This reverts commit 95ddce8895057f4834502aa45f7ad3be51c9c2af.
