### PR TITLE
🐛 Fix missing space

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -78,7 +78,7 @@ class CatalogController < ApplicationController
       qt: "search",
       rows: 10,
       qf: IiifPrint.config.metadata_fields.keys.map { |attribute| "#{attribute}_tesim" }
-                   .join(' ') << "title_tesim description_tesim all_text_timv file_set_text_tsimv",
+                   .join(' ') << " title_tesim description_tesim all_text_timv file_set_text_tsimv", # the first space character is necessary!
       "hl": true,
       "hl.simple.pre": "<span class='highlight'>",
       "hl.simple.post": "</span>",


### PR DESCRIPTION
This commit will fix collection_tesim and title_tesim searching because it was missing a space between the two fields.  This caused collection searching to not work and made adding a work to a collection hard to accomplish.

Ref:
  - https://github.com/scientist-softserv/adventist-dl/issues/516

# Expected Behavior Before Changes

Add to collection search was not working

# Expected Behavior After Changes

Add to collection search should now work

# Screenshots / Video

<img width="1086" alt="image" src="https://github.com/scientist-softserv/adventist-dl/assets/19597776/ca3ec6da-b602-4cde-9517-8c5709262186">
