### PR TITLE
🐛 Updating Bulkrax to v5.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,10 +89,7 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
-# rubocop:disable Metrics/LineLength
-# Bulkrax :: While we technically don't need a version when we tag on the branch, this helps us have a quick scan of what version we're assuming/working with.
-gem 'bulkrax', "~> 5.2.1", git: 'https://github.com/samvera-labs/bulkrax.git', ref: '0652a8428f65af1bbe9b6016336c760ac96447b2'
-# rubocop:enable Metrics/LineLength
+gem 'bulkrax', '~> 5.0'
 
 gem 'blacklight', '~> 6.7'
 gem 'blacklight_oai_provider', '~> 6.1', '>= 6.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,24 +1,4 @@
 GIT
-  remote: https://github.com/samvera-labs/bulkrax.git
-  revision: 0652a8428f65af1bbe9b6016336c760ac96447b2
-  ref: 0652a8428f65af1bbe9b6016336c760ac96447b2
-  specs:
-    bulkrax (5.2.1)
-      bagit (~> 0.4)
-      coderay
-      iso8601 (~> 0.9.0)
-      kaminari
-      language_list (~> 1.2, >= 1.2.1)
-      libxml-ruby (~> 3.2.4)
-      loofah (>= 2.2.3)
-      oai (>= 0.4, < 2.x)
-      rack (>= 2.0.6)
-      rails (>= 5.1.6)
-      rdf (>= 2.0.2, < 4.0)
-      rubyzip
-      simple_form
-
-GIT
   remote: https://github.com/samvera-labs/dog_biscuits.git
   revision: 56b3dc7099069b05d3441069910a91ae5726e77c
   specs:
@@ -225,6 +205,21 @@ GEM
       signet (~> 0.8)
       typhoeus
     builder (3.2.4)
+    bulkrax (5.3.0)
+      bagit (~> 0.4)
+      coderay
+      dry-monads (~> 1.4.0)
+      iso8601 (~> 0.9.0)
+      kaminari
+      language_list (~> 1.2, >= 1.2.1)
+      libxml-ruby (~> 3.2.4)
+      loofah (>= 2.2.3)
+      oai (>= 0.4, < 2.x)
+      rack (>= 2.0.6)
+      rails (>= 5.1.6)
+      rdf (>= 2.0.2, < 4.0)
+      rubyzip
+      simple_form
     byebug (11.1.3)
     cancancan (1.17.0)
     capybara (3.33.0)
@@ -1149,7 +1144,7 @@ DEPENDENCIES
   blacklight_oai_provider (~> 6.1, >= 6.1.1)
   blacklight_range_limit (= 6.5.0)
   bootstrap-datepicker-rails
-  bulkrax (~> 5.2.1)!
+  bulkrax (~> 5.0)
   byebug
   capybara
   carrierwave-aws (~> 1.3)


### PR DESCRIPTION
The previous version (e.g. 0652a8428f65af1bbe9b6016336c760ac96447b2) was on main and ahead of the v5.2.1 tag.

Below are the changes that will come as a result of these changes:

```
* e1d8a4e — 💸 Minting version 5.3.0 (#848) Jeremy Friesen, (2023-08-02) (HEAD -> main, tag: v5.3.0, origin/main, origin/HEAD)
* 032ce47 — 🐛 Normalizing export column names (#847) Jeremy Friesen, (2023-08-02)
* f2c2652 — Prefer [] over [""] for blank values that are split (#839) Rob Kaufman, (2023-08-02)
* 817e4bb — 🐛 Modify navtabs.js (#843) Kirk Wang, (2023-07-26)
* 6c67f16 — Remove jquery and bootstrap from bulkrax (#841) Kirk Wang, (2023-07-24)
* a8f6c16 — 🎁 Add title attribute (#838) Kirk Wang, (2023-07-20)
* 32dace9 — Re-enables nav-tabs for hydra apps (#836) Summer, (2023-07-17)
* 9330baa — Fix modal for hydra apps (#835) Summer, (2023-07-12)
* e6f2cf9 — 🐛 Move "|" button separator to be within conditional (#822) Benjamin Kiah Stroud, (2023-06-30)
* 1771217 — Fix create and validate button (#821) Deon The Dev, (2023-06-28)
* 858f472 — :gift: remove whitespaces from CSV headers (#816) Shana Moore, (2023-06-26)
* ae05be9 — :lipstick: fix cause of NoMethodError due to typo (#815) Shana Moore, (2023-06-16)
* 1b28da7 — 🎁 Adding indices to Bulkrax Tables (#813) Jeremy Friesen, (2023-06-14)
* 9beeddd — 📚 Add / correct documentation (#814) Benjamin Kiah Stroud, (2023-06-09)
```

The driver is the following pull request:

- https://github.com/samvera-labs/bulkrax/pull/847

The commit message for that change is as follows:

> Prior to this commit, when exporting a FileSet and GenericWork we'd
> see a "creator_1" and "creator" column.  The "creator" column might
> look as follows: `["Sandra Samvera"]`.  Which meant that creator was
> not an `ActiveTriples::Relation` (based on the prior logic).  Yet the
> "creator" field was stored as multi-value.  Perhaps having been
> previously coerced into an Array.
>
> With this commit, we're favoring the Bulkrax parser field mapping
> `"join"` configuration over whether or not the object is an
> =ActiveTriples::Relation=.  That is to say, if you told us to join the
> field, we're going to do that regardless of the data we have.
>
> Likewise, if the field's value is not an enumerable, we're not going
> to introduce an ordinal suffix (e.g. "creator_1" when we have a scalar
> creator).
>
> In other words don't do the join logic if we don't have an "array" or
> we weren't told to join arrays.
>
> Perhaps we could interrogate the model to ask if it's single value or
> not?  But this reduces the implementation knowledge of the properties
> by looking at a more primitive level (is the data multi-valued or
> not).

Related to:

- https://github.com/scientist-softserv/palni-palci/issues/624
