### PR TITLE
🎁 Jobs to clean & reimport pdfs

### DIFF
--- a/app/jobs/reload_pdfs_to_split_job.rb
+++ b/app/jobs/reload_pdfs_to_split_job.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+##
+# This job give the ability to rerun ingests where PDF splitting failed on a Bulkrax import.
+# @example
+#   switch!('sdapi'); ReloadPdfsToSplitJob.perform_later(work_type: "GenericWork")
+class ReloadPdfsToSplitJob < ApplicationJob
+  queue_as :reimport
+
+  retry_on StandardError, attempts: 0
+
+  ##
+  # @param id [String]: uuid or slug or nil
+  # @param work_type [String] work class
+  # @param logger [Logger]
+  def perform(id: nil, work_type: "JournalArticle", logger: Rails.logger)
+    @logger = logger
+    @context = ""
+    @counter = 0
+
+    if id.present?
+      process_single(id)
+    else
+      process_work_type(work_type)
+    end
+
+    logger.info("🚀🚀🚀 Finished submitting re-imports. Processed #{@counter} works")
+  end
+
+  attr_reader :logger
+
+  def process_single(id)
+    @context = "id: #{id}"
+    work = ActiveFedora::Base.find(id)
+    do_cleanup!(work)
+  rescue StandardError
+    logger.info("🚫 Work not found for #{@context}")
+  end
+
+  def process_work_type(work_type)
+    @context = "worktype: #{work_type}"
+
+    work_type.constantize.find_each do |w|
+      @context = "worktype: #{work_type}, work: #{w.to_param}"
+
+      # does this work have pdf filesets?
+      next unless w.file_sets&.map { |fs| fs.label.end_with?(".pdf") }.any?
+
+      # does this work have any children?
+      # For now we assume that if there are child works, it is correct.
+      # note: if we were to calculate the expected number of pages on each pdf,
+      #       we could also process in cases where we have some but not all of the
+      #       child works. For now we only process if there are no child works.
+      #       Single works can still be reprocessed by submitting with an id.
+      next unless w.child_works.none?
+
+      do_cleanup!(w)
+    end
+  rescue StandardError
+    logger.info("🚫 Unable to process #{@context}")
+  end
+
+  def do_cleanup!(work)
+    @counter += 1
+    logger.info("✅ Enqueuing re-import for #{@context}.")
+
+    ReloadSinglePdfJob.perform_later(work: work)
+  rescue StandardError => e
+    logger.error("😈😈😈 Error: #{e.message} for #{@context}")
+    raise e
+  end
+end

--- a/app/jobs/reload_single_pdf_job.rb
+++ b/app/jobs/reload_single_pdf_job.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+##
+# This job give the ability to reprocess works where PDF splitting failed
+# Given one work, it:
+# - Finds the bulkrax entry for the import
+# - Removes ALL filesets, child works, and pending children
+# - Removes pending relationships
+# - rebuilds the work's bulkrax entry
+class ReloadSinglePdfJob < ApplicationJob
+  queue_as :reimport
+
+  retry_on StandardError, attempts: 0
+
+  ##
+  # @param work [CurationConcern]: a work model object
+  # @param logger [Logger]
+  def perform(work:, logger: Rails.logger)
+    @logger = logger
+    @logger.info("🪖 Processing work #{work.to_param}")
+
+    # locate bulkrax work entry
+    entry = Bulkrax::Entry.find_by(identifier: work.identifier.first)
+    if entry
+      process_work(work: work, entry: entry)
+    else
+      @logger.info("🚫 Bulkrax::Entry not found for #{work.to_param}")
+      raise BulkraxEntryNotFound
+    end
+  end
+
+  def process_work(work:, entry:)
+    # destroy pending relationships & stray children
+    pending_relationships = IiifPrint::PendingRelationship.where(parent_id: work.id)
+    if pending_relationships.any?
+      destroy_potential_children_for(pending_relationships)
+      pending_relationships.each(&:destroy)
+    end
+
+    # destroy child works if any
+    work.child_works&.each { |child| child.destroy(eradicate: true) }
+
+    # destroy file set(s)
+    work.file_sets&.each { |fs| fs.destroy(eradicate: true) }
+
+    # rerun entry
+    @logger.info("💯 Submitting re-import of work #{work.to_param} via entry #{entry.class} ID=#{entry.id}")
+
+    entry.build
+    entry.save
+    # not sure why this is needed
+    work = entry.factory.find
+    work.save
+  rescue StandardError => e
+    @logger.error("😈😈😈 Reimport error: #{e.message} for #{work.to_param}")
+    raise e
+  end
+
+  def destroy_potential_children_for(pending_relationships)
+    pending_relationships.each do |pending|
+      child = ActiveFedora::Base.where(title_tesim: [pending.child_title])
+      next unless child
+      child.each do |rcd|
+        rcd.destroy(eradicate: true)
+      end
+    end
+  end
+
+  class BulkraxEntryNotFound < StandardError; end
+end


### PR DESCRIPTION
# Story

Creates two jobs to fix PDF splitting issues originating via a Bulkrax import.

Refs: 
- #506

Deploy code, then run in rails console:
```
switch! 'sdapi'
ReloadPdfsToSplitJob.perform_later(work_type: "JournalArticle")
```
# Expected Behavior Before Changes
Works did not split PDFs so UV does not display.

# Expected Behavior After Changes
A Bulkrax-imported work with an attached PDF file_set but no child works will be reimported.

# Screenshots / Video

<details>
<summary>Before:</summary>

![Screenshot 2023-08-07 at 9 17 32 PM](https://github.com/scientist-softserv/adventist-dl/assets/17851674/40372971-7da5-4c4f-8304-dedbb0902cc1)

</details>
<details>
<summary>after:</summary>

![Screenshot 2023-08-07 at 9 20 35 PM](https://github.com/scientist-softserv/adventist-dl/assets/17851674/e839a0d7-5a45-4ced-a5f0-02e0ab6ed4f0)
![Screenshot 2023-08-07 at 9 20 39 PM](https://github.com/scientist-softserv/adventist-dl/assets/17851674/14290c46-38a4-47c4-a8cd-7482a763063b)

</details>

# Notes:
