### PR TITLE
🐛 Update IiifPrint gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -143,6 +143,6 @@ gem 'dog_biscuits', git: 'https://github.com/samvera-labs/dog_biscuits.git'
 
 gem 'hyrax-v2_graph_indexer', git: 'https://github.com/scientist-softserv/hyrax-v2_graph_indexer', branch: 'main'
 # rubocop:disable Metrics/LineLength
-gem 'iiif_print', git: 'https://github.com/scientist-softserv/iiif_print.git', ref: '9e7837ce4bd08bf8fff9126455d0e0e2602f6018'
+gem 'iiif_print', git: 'https://github.com/scientist-softserv/iiif_print.git', ref: '5fb1531c2aa4c4797aea5a83c74797148a9fbc32'
 # rubocop:enable Metrics/LineLength
 gem 'order_already'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,16 +16,15 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: 9e7837ce4bd08bf8fff9126455d0e0e2602f6018
-  ref: 9e7837ce4bd08bf8fff9126455d0e0e2602f6018
+  revision: 5fb1531c2aa4c4797aea5a83c74797148a9fbc32
+  ref: 5fb1531c2aa4c4797aea5a83c74797148a9fbc32
   specs:
     iiif_print (1.0.0)
-      blacklight_iiif_search (~> 1.0)
+      blacklight_iiif_search (>= 1.0, < 3.0)
       derivative-rodeo (~> 0.5)
-      dry-monads (~> 1.4.0)
-      hyrax (>= 2.5, < 4)
+      hyrax (>= 2.5, < 6)
       nokogiri (>= 1.13.2)
-      rails (~> 5.0)
+      rails (>= 5.0, < 8.0)
       rdf-vocab (~> 3.0)
 
 GIT
@@ -271,7 +270,7 @@ GEM
     deep_merge (1.2.1)
     deprecation (1.1.0)
       activesupport
-    derivative-rodeo (0.5.0)
+    derivative-rodeo (0.5.1)
       activesupport (>= 5)
       aws-sdk-s3
       aws-sdk-sqs

--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ The full spec suite can be run in docker locally. There are several ways to do t
 docker-compose exec web rake
 ```
 
+#### Update Dependencies
+
+You can edit the Gemfile then run:
+
+```bash
+docker compose -f ./docker-compose.yml -f ./docker-compose.bundle.yml up
+```
+
+The above will make sure to bundle the updated gems.
+
 ### With out Docker
 
 Please note that this is unused by most contributors at this point and will likely become unsupported in a future release of Hyku unless someone in the community steps up to maintain it.

--- a/docker-compose.bundle.yml
+++ b/docker-compose.bundle.yml
@@ -1,0 +1,11 @@
+# Copy file to docker-compose.override.yml to override docker-compose.yml
+# Only use for local development
+version: '3.8'
+services:
+  # Uncomment to allow for the use of a ruby debugger (byebug, pry, etc) in Docker.
+  # See http://playbook-staging.notch8.com/en/devops/docker_debugger for more info.
+  web:
+    command: sh -l -c "bundle && bundle exec puma -v -b tcp://0.0.0.0:3000"
+  worker:
+    command: sh -l -c "bundle && bundle exec sidekiq"
+


### PR DESCRIPTION
The log between the previous SHA of IiifPrint and the new one had the
following:

```
❯ git slog 9e7837ce4bd08bf8fff9126455d0e0e2602f6018..5fb1531c2aa4c4797aea5a83c74797148a9fbc32 --no-merges
* 4b4165f — 🎁 Add graceful fallback of preprocessing Jeremy Friesen, (2023-11-06) (origin/i282-gracefully-handling-of-copy-failure, i282-gracefully-handling-of-copy-failure)
* f8f9a90 — increase blacklight_iiif_search window Rob Kaufman, (2023-10-18) (origin/rails_version)
* 7fd53d6 — iiif_print doesnt use monads Rob Kaufman, (2023-10-17)
* b6352fa — loosen up hyrax too Rob Kaufman, (2023-10-17)
* a335c68 — Loosen up rails restriction Rob Kaufman, (2023-10-17)
* b170a57 — 🐛 Handle no file_set_ids property Jeremy Friesen, (2023-08-15) (adding-bug-fix)
* 7f34a12 — :broom: Update method call to new Shana Moore, (2023-08-22)
* 0af836f — 🐛 Fix calling Fedora from view Kirk Wang, (2023-08-22)
* e8e19df — Update app/views/hyrax/base/_representative_media.html.erb Jeremy Friesen, (2023-08-18)
* 95eed39 — 🐛 Render thumbnails when IIIF Print disabled Jeremy Friesen, (2023-08-18) (enable-thumbnails-when-iiif-print-disabled)
```

I'm also including the `docker-compose.bundle.yml` file.  With the
application spun down I edited the `Gemfile` then ran:

```bash
docker compose -f ./docker-compose.yml -f ./docker-compose.bundle.yml up
```

That bundled the gems.  To get the updated logging in the Derivative
Rodeo, I then shelled into the web container and ran:

```
bundle update derivative-rodeo --conservative
```

Yes the above `derivative-rodeo` is intentional instead of
`derivative_rodeo` which maps to the repository name; there are rubygems
issues to resolve.

Related to:

- https://github.com/scientist-softserv/derivative_rodeo/pull/70