### PR TITLE
:broom: Set nested_relationship_reindexer in Hyrax initializer

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -188,6 +188,8 @@ Hyrax.config do |config|
     uri.sub(%r{/info\.json\Z}, '')
   end
 
+  config.nested_relationship_reindexer = ->(id:, extent:) {}
+
 end
 
 Date::DATE_FORMATS[:standard] = "%m/%d/%Y"


### PR DESCRIPTION
In this commit we are setting nested_relationship_reindexer in the Hyrax initializer to use the nested indexer.

