### PR TITLE
:broom: Update iiif_print to improve error logging message

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -143,6 +143,6 @@ gem 'dog_biscuits', git: 'https://github.com/samvera-labs/dog_biscuits.git'
 
 gem 'hyrax-v2_graph_indexer', git: 'https://github.com/scientist-softserv/hyrax-v2_graph_indexer', branch: 'main'
 # rubocop:disable Metrics/LineLength
-gem 'iiif_print', git: 'https://github.com/scientist-softserv/iiif_print.git', ref: '5fb1531c2aa4c4797aea5a83c74797148a9fbc32'
+gem 'iiif_print', git: 'https://github.com/scientist-softserv/iiif_print.git', ref: '56069b5f8bbcbf6629b9973352069d21d5ddaf0f'
 # rubocop:enable Metrics/LineLength
 gem 'order_already'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,8 +16,8 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: 5fb1531c2aa4c4797aea5a83c74797148a9fbc32
-  ref: 5fb1531c2aa4c4797aea5a83c74797148a9fbc32
+  revision: 56069b5f8bbcbf6629b9973352069d21d5ddaf0f
+  ref: 56069b5f8bbcbf6629b9973352069d21d5ddaf0f
   specs:
     iiif_print (1.0.0)
       blacklight_iiif_search (>= 1.0, < 3.0)


### PR DESCRIPTION
The error message was too vague and not helpful. This PR pulls in the following: 
![image](https://github.com/scientist-softserv/adventist-dl/assets/10081604/6bef9b2a-63ea-44d5-9b84-fb96018bf6f1)


ref:

- https://github.com/scientist-softserv/iiif_print/pull/284
