### PR TITLE
Update helm_deploy

### DIFF
--- a/bin/helm_deploy
+++ b/bin/helm_deploy
@@ -23,8 +23,7 @@ WORKER_IMAGE="${WORKER_IMAGE:-ghcr.io/samvera/hyku/worker}"
 DEPLOY_TAG="${DEPLOY_TAG:-latest}"
 WORKER_TAG="${WORKER_TAG:-$DEPLOY_TAG}"
 
-helm pull --untar oci://ghcr.io/samvera/hyrax/hyrax-helm --version 1.0.0
-
+helm pull --untar oci://ghcr.io/samvera/hyrax/hyrax-base:hyrax-v5.0.0.rc2
 helm repo update
 
 helm upgrade \

--- a/bin/helm_deploy
+++ b/bin/helm_deploy
@@ -23,7 +23,7 @@ WORKER_IMAGE="${WORKER_IMAGE:-ghcr.io/samvera/hyku/worker}"
 DEPLOY_TAG="${DEPLOY_TAG:-latest}"
 WORKER_TAG="${WORKER_TAG:-$DEPLOY_TAG}"
 
-helm pull --untar oci://ghcr.io/samvera/hyrax/hyrax-helm --version 3.5.0
+helm pull --untar oci://ghcr.io/samvera/hyrax/hyrax-helm --version 1.0.0
 
 helm repo update
 

--- a/bin/helm_deploy
+++ b/bin/helm_deploy
@@ -23,7 +23,8 @@ WORKER_IMAGE="${WORKER_IMAGE:-ghcr.io/samvera/hyku/worker}"
 DEPLOY_TAG="${DEPLOY_TAG:-latest}"
 WORKER_TAG="${WORKER_TAG:-$DEPLOY_TAG}"
 
-helm pull --untar oci://ghcr.io/samvera/hyrax/hyrax-base:hyrax-v5.0.0.rc2
+helm pull --untar oci://ghcr.io/samvera/hyrax/hyrax-base --version hyrax-v5.0.0.rc2
+
 helm repo update
 
 helm upgrade \


### PR DESCRIPTION
Deploying main is causing an error. I believe it's because we upgraded helm_deploy version from 0.22.0 to 3.5.0.
3.5.0 doesn't seem to exist though - 

ref:
- https://github.com/orgs/samvera/packages/container/hyrax%2Fhyrax-helm/versions?filters%5Bversion_type%5D=tagged

