### PR TITLE
🎁 add helpful query attributes to iiif_print_pending_relationships

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -142,6 +142,6 @@ gem 'blacklight_range_limit', '6.5.0'
 gem 'dog_biscuits', git: 'https://github.com/samvera-labs/dog_biscuits.git'
 gem 'hyrax-v2_graph_indexer', git: 'https://github.com/scientist-softserv/hyrax-v2_graph_indexer', branch: 'main'
 # rubocop:disable Metrics/LineLength
-gem 'iiif_print', git: 'https://github.com/scientist-softserv/iiif_print.git', ref: '56069b5f8bbcbf6629b9973352069d21d5ddaf0f'
+gem 'iiif_print', git: 'https://github.com/scientist-softserv/iiif_print.git', branch: 'add-models-to-pending-relationships-table'
 # rubocop:enable Metrics/LineLength
 gem 'order_already'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,15 +16,16 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: 56069b5f8bbcbf6629b9973352069d21d5ddaf0f
-  ref: 56069b5f8bbcbf6629b9973352069d21d5ddaf0f
+  revision: 1c9daacba799bea3b125acf39c44bcfda9038b4d
+  branch: add-models-to-pending-relationships-table
   specs:
     iiif_print (1.0.0)
-      blacklight_iiif_search (>= 1.0, < 3.0)
+      blacklight_iiif_search (~> 1.0)
       derivative-rodeo (~> 0.5)
-      hyrax (>= 2.5, < 6)
+      dry-monads (~> 1.4.0)
+      hyrax (>= 2.5, < 4)
       nokogiri (>= 1.13.2)
-      rails (>= 5.0, < 8.0)
+      rails (~> 5.0)
       rdf-vocab (~> 3.0)
 
 GIT

--- a/db/migrate/20231110163052_add_model_details_to_iiif_print_pending_relationships.rb
+++ b/db/migrate/20231110163052_add_model_details_to_iiif_print_pending_relationships.rb
@@ -2,5 +2,6 @@ class AddModelDetailsToIiifPrintPendingRelationships < ActiveRecord::Migration[5
   def change
     add_column :iiif_print_pending_relationships, :parent_model, :string
     add_column :iiif_print_pending_relationships, :child_model, :string
+    add_column :iiif_print_pending_relationships, :file_id, :string
   end
 end

--- a/db/migrate/20231110163052_add_model_details_to_iiif_print_pending_relationships.rb
+++ b/db/migrate/20231110163052_add_model_details_to_iiif_print_pending_relationships.rb
@@ -1,0 +1,6 @@
+class AddModelDetailsToIiifPrintPendingRelationships < ActiveRecord::Migration[5.2]
+  def change
+    add_column :iiif_print_pending_relationships, :parent_model, :string
+    add_column :iiif_print_pending_relationships, :child_model, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_08_153601) do
+ActiveRecord::Schema.define(version: 2023_11_10_163052) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -377,6 +377,8 @@ ActiveRecord::Schema.define(version: 2023_06_08_153601) do
     t.string "child_order", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "parent_model"
+    t.string "child_model"
     t.index ["parent_id"], name: "index_iiif_print_pending_relationships_on_parent_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -379,6 +379,7 @@ ActiveRecord::Schema.define(version: 2023_11_10_163052) do
     t.datetime "updated_at", null: false
     t.string "parent_model"
     t.string "child_model"
+    t.string "file_id"
     t.index ["parent_id"], name: "index_iiif_print_pending_relationships_on_parent_id"
   end
 

--- a/lib/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter.rb
+++ b/lib/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter.rb
@@ -17,7 +17,7 @@ module IiifPrint
       #
       # @see https://github.com/scientist-softserv/iiif_print/blob/a23706453f23e0f54c9d50bbf0ddf9311d82a0b9/lib/iiif_print/jobs/child_works_from_pdf_job.rb#L39-L63
       def self.call(path,
-                    splitter: DerivativeRodeoSplitter,
+                    splitter: Rails.env.development? ? PagesToJpgsSplitter : DerivativeRodeoSplitter,
                     suffixes: CreateDerivativesJobDecorator::NON_ARCHIVAL_PDF_SUFFIXES,
                     **args)
         return [] if suffixes.any? { |suffix| path.downcase.end_with?(suffix) }


### PR DESCRIPTION
In this PR we are setting up the pending relationships table to make it easier to find relations.

related to 
- https://github.com/scientist-softserv/iiif_print/pull/288 

It will add parent_model, child_model, and file_id to the iiif_print_pending_relationships table.

TODO: update iiif print once the related PR gets merged into iiif print