### PR TITLE
:gift: delete child works if the parent work is deleted

### DIFF
--- a/app/models/concerns/destroyable_children.rb
+++ b/app/models/concerns/destroyable_children.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module DestroyableChildren
+  extend ActiveSupport::Concern
+
+  included do
+    before_destroy :destroy_children
+  end
+
+  private
+
+    def destroy_children
+      ordered_works.each(&:destroy)
+    end
+end

--- a/app/models/conference_item.rb
+++ b/app/models/conference_item.rb
@@ -20,6 +20,7 @@ class ConferenceItem < DogBiscuits::ConferenceItem
   before_save :combine_dates
 
   prepend OrderAlready.for(:creator)
+  include DestroyableChildren
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
     pdf_splitter_service: IiifPrint::SplitPdfs::AdventistPagesToJpgsSplitter,

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -20,6 +20,7 @@ class Dataset < DogBiscuits::Dataset
   before_save :combine_dates
 
   prepend OrderAlready.for(:creator)
+  include DestroyableChildren
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
     pdf_splitter_service: IiifPrint::SplitPdfs::AdventistPagesToJpgsSplitter,

--- a/app/models/exam_paper.rb
+++ b/app/models/exam_paper.rb
@@ -19,7 +19,7 @@ class ExamPaper < DogBiscuits::ExamPaper
   before_save :combine_dates
 
   prepend OrderAlready.for(:creator)
-
+  include DestroyableChildren
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
     pdf_splitter_service: IiifPrint::SplitPdfs::AdventistPagesToJpgsSplitter,

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -12,6 +12,7 @@ class GenericWork < ActiveFedora::Base
   include SlugMetadata
   include AdventistMetadata
   include SlugBug
+  include DestroyableChildren
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
     pdf_splitter_service: IiifPrint::SplitPdfs::AdventistPagesToJpgsSplitter,

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -11,6 +11,7 @@ class Image < ActiveFedora::Base
   include DogBiscuits::Geo
   include DogBiscuits::PartOf
   include DogBiscuits::PlaceOfPublication
+  include DestroyableChildren
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
     pdf_splitter_service: IiifPrint::SplitPdfs::AdventistPagesToJpgsSplitter,

--- a/app/models/journal_article.rb
+++ b/app/models/journal_article.rb
@@ -24,6 +24,7 @@ class JournalArticle < DogBiscuits::JournalArticle
   before_save :combine_dates
 
   prepend OrderAlready.for(:creator)
+  include DestroyableChildren
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
     pdf_splitter_service: IiifPrint::SplitPdfs::AdventistPagesToJpgsSplitter,

--- a/app/models/published_work.rb
+++ b/app/models/published_work.rb
@@ -25,6 +25,7 @@ class PublishedWork < DogBiscuits::PublishedWork
   before_save :combine_dates
 
   prepend OrderAlready.for(:creator)
+  include DestroyableChildren
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
     pdf_splitter_service: IiifPrint::SplitPdfs::AdventistPagesToJpgsSplitter,

--- a/app/models/thesis.rb
+++ b/app/models/thesis.rb
@@ -27,6 +27,7 @@ class Thesis < DogBiscuits::Thesis
   before_save :combine_dates
 
   prepend OrderAlready.for(:creator)
+  include DestroyableChildren
   include IiifPrint.model_configuration(
     pdf_split_child_model: self,
     pdf_splitter_service: IiifPrint::SplitPdfs::AdventistPagesToJpgsSplitter,

--- a/spec/models/concerns/destroyable_children_spec.rb
+++ b/spec/models/concerns/destroyable_children_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DestroyableChildren, type: :model do
+  describe Image do
+    let(:parent) { create(:image) }
+    let(:child1) { create(:image) }
+    let(:child2) { create(:image) }
+
+    before do
+      allow(parent).to receive(:ordered_works).and_return([child1, child2])
+    end
+
+    it 'destroys child works when the parent is destroyed' do
+      expect { parent.destroy }.to change(Image, :count).by(-3)
+    end
+  end
+end


### PR DESCRIPTION
# Story

TODO: This solution is too aggressive. This solution deletes anything in parent.ordered_works when the parent gets deleted, when really we want to delete any child works derived from the deleted PDF of a parent work. 


In IiifPrint, 
When a file set (PDF) gets deleted we will need to find the child works (pages) and any pending relationships related to it. 

we should have a relationships or pending relationships (maybe sometimes both). delete the related
see #destroy_potential_children. Don't target all the PDFs. Only pending relationships for specific pdf.

See reload_single_pdf_job.rb (but this is too aggressive also and would only work for adventist).

Refs:

- #issuenumber

# Expected Behavior Before Changes

# Expected Behavior After Changes

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes
