### PR TITLE
add-service-port-nginx

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -266,7 +266,10 @@ externalSolrPort: 8983
 externalSolrUser: admin
 externalSolrPassword: $SOLR_ADMIN_PASSWORD
 externalSolrCollection: "hyku-adventist-production"
+
 nginx:
+  service:
+    port: 80
   enabled: true
   image:
     registry: registry.gitlab.com


### PR DESCRIPTION
adds the service port to nginx, once it's enabled the hyrax chart expects those values to be set in the values file

# Story
Deploy on main fails after adding the nginx service to the values file for the production deployment. Adding the service port to the values file under the nginx service will elleviate the error and have the deployment back on track in no time!
# Expected Behavior Before Changes

# Expected Behavior After Changes

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes
