### PR TITLE
Raise an error in import_url_job

### DIFF
--- a/app/jobs/import_url_job_decorator.rb
+++ b/app/jobs/import_url_job_decorator.rb
@@ -18,8 +18,7 @@ module ImportUrlJobDecorator
           %(ImportUrlJob: Error copying <#{uri}> to #{dir} with #{e.message}.  #{e.backtrace.join("\n")})
         )
         send_error(e.message)
-        # TODO: Should we re-raise the exception?  As written this copy_remote_file has a false
-        # success.
+        raise "File #{filename} attachment failed for File Set ID #{file_set.id}, with errors #{e.message}"
       end
     end
     Rails.logger.debug("ImportUrlJob: Copying <#{uri}> to #{dir}, closing #{File.join(dir, filename)}")


### PR DESCRIPTION
# Story

Errors show on notifications dashboard but jobs complete normally. Raise an error so we can rerun jobs if failure occurs.

# Expected Behavior Before Changes

Errors appear in mailboxer notifications only.

# Expected Behavior After Changes

Job ends in error.

# Screenshots / Video

<details>
<summary></summary>

![Screenshot 2023-11-20 at 6 04 25 PM](https://github.com/scientist-softserv/adventist-dl/assets/17851674/aa875ec8-5d7f-4dce-86fc-986a286b9dac)

</details>

# Notes
