### PR TITLE
🐛 Add ternary to support local development

### DIFF
--- a/lib/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter.rb
+++ b/lib/iiif_print/split_pdfs/adventist_pages_to_jpgs_splitter.rb
@@ -17,7 +17,7 @@ module IiifPrint
       #
       # @see https://github.com/scientist-softserv/iiif_print/blob/a23706453f23e0f54c9d50bbf0ddf9311d82a0b9/lib/iiif_print/jobs/child_works_from_pdf_job.rb#L39-L63
       def self.call(path,
-                    splitter: DerivativeRodeoSplitter,
+                    splitter: Rails.env.development? ? PagesToJpgsSplitter : DerivativeRodeoSplitter,
                     suffixes: CreateDerivativesJobDecorator::NON_ARCHIVAL_PDF_SUFFIXES,
                     **args)
         return [] if suffixes.any? { |suffix| path.downcase.end_with?(suffix) }


### PR DESCRIPTION
This commit adds a ternary to use PagesToJpgsSplitter during local development. Otherwise we get errors about AWS credentials.

![image](https://github.com/scientist-softserv/adventist-dl/assets/10081604/6038b1b3-f68e-4280-ab35-245e1338b8f4)