### PR TITLE
🐛 Skip derivative generation for thumbnails

### DIFF
--- a/app/jobs/create_derivatives_job_decorator.rb
+++ b/app/jobs/create_derivatives_job_decorator.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# OVERRIDE HYRAX 2.9.5 to conditionally skip derivative generation
-
+# OVERRIDE HYRAX 2.9.6 to conditionally skip derivative generation
 module CreateDerivativesJobDecorator
   # @note Override to include conditional validation
   def perform(file_set, file_id, filepath = nil)
@@ -9,18 +8,25 @@ module CreateDerivativesJobDecorator
     super
   end
 
+  ##
   # @see https://github.com/scientist-softserv/adventist-dl/issues/311 for discussion on structure
   #      of non-Archival PDF.
   NON_ARCHIVAL_PDF_SUFFIXES = [".reader.pdf", ".pdf-r.pdf"].freeze
 
+  ##
+  # We should not be creating derivatives for thumbnails.
+  FILE_SUFFIXES_TO_SKIP_DERIVATIVE_CREATION = ([".tn.jpg", ".tn.png"] + NON_ARCHIVAL_PDF_SUFFIXES).freeze
+
+  # rubocop:disable Metrics/LineLength
   def self.create_derivative_for?(file_set:)
     # Our options appear to be `file_set.label` or `file_set.original_file.original_name`; in
     # favoring `#label` we are avoiding a call to Fedora.  Is the label likely to be the original
     # file name?  I hope so.
-    return false if NON_ARCHIVAL_PDF_SUFFIXES.any? { |suffix| file_set.label.downcase.end_with?(suffix) }
+    return false if FILE_SUFFIXES_TO_SKIP_DERIVATIVE_CREATION.any? { |suffix| file_set.label.downcase.end_with?(suffix) }
 
     true
   end
+  # rubocop:enable Metrics/LineLength
 end
 
 CreateDerivativesJob.prepend(CreateDerivativesJobDecorator)

--- a/spec/jobs/create_derivatives_job_decorator_spec.rb
+++ b/spec/jobs/create_derivatives_job_decorator_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe CreateDerivativesJobDecorator do
 
     let(:file_set) { double(FileSet, label: label) }
 
-    context 'when the file set is for a non-archival PDF' do
-      let(:label) { "my-non-archival#{described_class::NON_ARCHIVAL_PDF_SUFFIXES.first}" }
+    context 'when the file set is for a skipped suffix' do
+      let(:label) { "my-non-archival#{described_class::FILE_SUFFIXES_TO_SKIP_DERIVATIVE_CREATION.first}" }
 
       it { is_expected.to be_falsey }
     end


### PR DESCRIPTION
We're seeing jobs that are trying to find the HOCR of a thumbnail; we don't need that HOCR and it's spawning 5 jobs that are unecessary.

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/311
