### PR TITLE
Restore creating thumbnails of thumbnails

### DIFF
--- a/app/jobs/create_derivatives_job_decorator.rb
+++ b/app/jobs/create_derivatives_job_decorator.rb
@@ -15,7 +15,7 @@ module CreateDerivativesJobDecorator
 
   ##
   # We should not be creating derivatives for thumbnails.
-  FILE_SUFFIXES_TO_SKIP_DERIVATIVE_CREATION = ([".tn.jpg", ".tn.png"] + NON_ARCHIVAL_PDF_SUFFIXES).freeze
+  FILE_SUFFIXES_TO_SKIP_DERIVATIVE_CREATION = ([] + NON_ARCHIVAL_PDF_SUFFIXES).freeze
 
   # rubocop:disable Metrics/LineLength
   def self.create_derivative_for?(file_set:)


### PR DESCRIPTION
# Story

In an attempt to get rid of unnecessary, failing attempts to run HOCR on the thumbnail, the attempted solution went too far.

Ref 
- https://github.com/scientist-softserv/adventist-dl/pull/674

The thumbnail file that is attached requires derivatives to create a thumbnail of the thumbnail. The thumbnail's thumbnail becomes the work's thumbnail, so without the redundant processing, the work has no thumbnail.

# Expected Behavior Before Changes

Ingested works have no thumbnails in the index views.
<details>

![Screenshot 2023-11-24 at 2 58 22 PM](https://github.com/scientist-softserv/adventist-dl/assets/17851674/07dd19e0-a7fc-4b4a-8800-62159bfd1051)
![Screenshot 2023-11-24 at 2 58 36 PM](https://github.com/scientist-softserv/adventist-dl/assets/17851674/4e96b4c2-2371-4ecd-a68a-02cbf4613b4b)

</details>

# Expected Behavior After Changes

Ingested works have thumbnails in the index views.
<details>

![Screenshot 2023-11-24 at 2 56 41 PM](https://github.com/scientist-softserv/adventist-dl/assets/17851674/dbbb27b3-72d8-4e2b-a8c3-1ff2b4d7683f)
![Screenshot 2023-11-24 at 3 09 46 PM](https://github.com/scientist-softserv/adventist-dl/assets/17851674/dd1811f2-89f1-4539-8122-c948c6570c0c)

</details>

# Notes
