### PR TITLE
♻️ Deprioritize generating ChildWorks

### DIFF
--- a/config/initializers/good_job.rb
+++ b/config/initializers/good_job.rb
@@ -34,6 +34,7 @@ Rails.application.config.after_initialize do
   AttachFilesToWorkJob.priority = -1
   Bulkrax::ImportWorkJob.priority = -5
   Bulkrax::ImportFileSetJob.priority = -15
+  IiifPrint::Jobs::ChildWorksFromPdfJob.priority = -17
   Bulkrax::CreateRelationshipsJob.priority = -20
   Bulkrax::ImporterJob.priority = -20
   IiifPrint::Jobs::CreateRelationshipsJob.priority = -20


### PR DESCRIPTION
Prior to this commit, the job happened at medium priority.  However with
the incorporation of PDF.js, we have a suitable viewer experience such
that splitting the PDF is of lower concern than getting works into the
system.

Related to:

- https://github.com/scientist-softserv/adventist-dl/issues/667