### PR TITLE
🐛 Fix for UV when characterize job fails

### DIFF
--- a/app/services/iiif_print/manifest_builder_service_behavior_decorator.rb
+++ b/app/services/iiif_print/manifest_builder_service_behavior_decorator.rb
@@ -18,7 +18,9 @@ IiifPrint::ManifestBuilderServiceBehavior.module_eval do
   end
 
   def rendering(presenter:)
-    file_set_presenters = presenter.file_set_presenters.reject { |fsp| fsp.mime_type.include?('image') }
+    file_set_presenters = presenter.file_set_presenters.select do |fsp|
+      fsp.mime_type && !fsp.mime_type.include?('image')
+    end
 
     file_set_presenters.map do |fsp|
       {


### PR DESCRIPTION
The problem here is that we are trying to render download options for non-image files in the UV.  The original logic rejects anything that is an image so PDFs, TXT, etc can be downloaded through the UV.  However, if the characterize job fails then we have a `nil` for the mime type which is why the error is thrown.  This commit will rework the logic to account for that.

Ref:
  - https://github.com/scientist-softserv/adventist-dl/issues/679
