### PR TITLE
DRAFT: fcrepo_endpoint monitor support

### DIFF
--- a/app/models/fcrepo_endpoint.rb
+++ b/app/models/fcrepo_endpoint.rb
@@ -12,11 +12,15 @@ class FcrepoEndpoint < Endpoint
   end
 
   def ping
-    ActiveFedora::Fedora.instance.connection.head(
+    if ActiveFedora::Fedora.instance.connection.head(
       ActiveFedora::Fedora.instance.connection.connection.http.url_prefix.to_s
     ).response.success?
-  rescue StandardError
-    false
+      "Fedora is OK"
+    else
+      "Fedora is Down"
+    end
+  rescue StandardError => e
+    "Error checking Fedora status: #{e.message}"
   end
 
   # Remove the Fedora resource for this endpoint, then destroy the record

--- a/app/models/fcrepo_endpoint.rb
+++ b/app/models/fcrepo_endpoint.rb
@@ -17,7 +17,7 @@ class FcrepoEndpoint < Endpoint
     ).response.success?
       "Fedora is OK"
     else
-      "Fedora is Down"
+      "Error checking Fedora status: Fedora is Down"
     end
   rescue StandardError => e
     "Error checking Fedora status: #{e.message}"

--- a/spec/models/fcrepo_endpoint_spec.rb
+++ b/spec/models/fcrepo_endpoint_spec.rb
@@ -2,30 +2,41 @@
 
 RSpec.describe FcrepoEndpoint do
   let(:base_path) { 'foobar' }
+  subject { described_class.new base_path: base_path }
 
   describe '.options' do
-    subject { described_class.new base_path: base_path }
-
     it 'uses the configured application settings' do
       expect(subject.options[:base_path]).to eq base_path
     end
   end
 
   describe '#ping' do
-    let(:success_response) { double(response: double(success?: true)) }
+    let(:url_prefix) { ActiveFedora::Fedora.instance.connection.connection.http.url_prefix.to_s }
 
-    it 'checks if the service is up' do
-      allow(ActiveFedora::Fedora.instance.connection).to receive(:head).with(
-        ActiveFedora::Fedora.instance.connection.connection.http.url_prefix.to_s
-      ).and_return(success_response)
-      expect(subject.ping).to be_truthy
+    context 'when Fedora is accessible' do
+      let(:success_response) { double(response: double(success?: true)) }
+
+      it 'returns "Fedora is OK"' do
+        allow(ActiveFedora::Fedora.instance.connection).to receive(:head).with(url_prefix).and_return(success_response)
+        expect(subject.ping).to eq("Fedora is OK")
+      end
     end
 
-    it 'is false if the service is down' do
-      allow(ActiveFedora::Fedora.instance.connection).to receive(:head).with(
-        ActiveFedora::Fedora.instance.connection.connection.http.url_prefix.to_s
-      ).and_raise(RuntimeError)
-      expect(subject.ping).to be_falsey
+    context 'when Fedora is down' do
+      let(:failure_response) { double(response: double(success?: false)) }
+
+      it 'returns "Fedora is Down"' do
+        allow(ActiveFedora::Fedora.instance.connection).to receive(:head).with(url_prefix).and_return(failure_response)
+        expect(subject.ping).to eq("Fedora is Down")
+      end
+    end
+
+    context 'when an error occurs' do
+      it 'returns a custom error message with the error details' do
+        error_message = "Network error"
+        allow(ActiveFedora::Fedora.instance.connection).to receive(:head).and_raise(StandardError.new(error_message))
+        expect(subject.ping).to eq("Error checking Fedora status: #{error_message}")
+      end
     end
   end
 end

--- a/spec/models/fcrepo_endpoint_spec.rb
+++ b/spec/models/fcrepo_endpoint_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe FcrepoEndpoint do
 
       it 'returns "Fedora is Down"' do
         allow(ActiveFedora::Fedora.instance.connection).to receive(:head).with(url_prefix).and_return(failure_response)
-        expect(subject.ping).to eq("Fedora is Down")
+        expect(subject.ping).to eq("Error checking Fedora status: Fedora is Down")
       end
     end
 

--- a/spec/models/fcrepo_endpoint_spec.rb
+++ b/spec/models/fcrepo_endpoint_spec.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe FcrepoEndpoint do
-  let(:base_path) { 'foobar' }
   subject { described_class.new base_path: base_path }
+
+  let(:base_path) { 'foobar' }
 
   describe '.options' do
     it 'uses the configured application settings' do


### PR DESCRIPTION
- Add more detailed response.success to target for fedora for s24x7 monitor support
- Update rspec tests to account for new support.

# Story
When Fedora goes down we have no way of knowing. In order to add a monitor for the service I needed to ensure that the response.success I was targeting wasn't just the word "Ok" since the other services use the same response, I was getting false positives upon testing the status, and after deliberately taking the fcrepo service down in docker to imitate the service being down.

# Screenshot

Dev
<img width="1001" alt="Screenshot 2024-03-28 at 23 35 27" src="https://github.com/scientist-softserv/adventist-dl/assets/63515648/b08bf680-c09b-4b7d-ac72-b4c3d2192ccd">


Production (To show what it looked like before the PR because I forgot to take a screenshot of dev before I deployed this)
<img width="1000" alt="Screenshot 2024-03-28 at 23 37 37" src="https://github.com/scientist-softserv/adventist-dl/assets/63515648/cb5d23d1-89ef-402d-82c8-fc09473ba7e4">

