### PR TITLE
dont-cluster-redis

### DIFF
--- a/ops/dev-deploy.tmpl.yaml
+++ b/ops/dev-deploy.tmpl.yaml
@@ -399,8 +399,8 @@ fcrepo:
 postgresql:
   enabled: false
 redis:
-  cluster:
-    enabled: false
+  replica:
+    replicaCount: 1
   password: $REDIS_PASSWORD
 solr:
   enabled: false


### PR DESCRIPTION
Redis should not be clustered. Looks like the version of redis' values changed to accomodate clustered replicas differently, updating the values file to acocmodate


redis' subchart defualt values file list:
```

## @section Redis&reg; replicas configuration parameters
##

replica:
  ## @param replica.replicaCount Number of Redis&reg; replicas to deploy
  ##
  replicaCount: 3
```
